### PR TITLE
Make offline_memory pub in memory controller

### DIFF
--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -101,7 +101,7 @@ pub struct MemoryController<F> {
     memory: Memory<F>,
 
     /// A reference to the `OfflineMemory`. Will be populated after `finalize()`.
-    offline_memory: Arc<Mutex<OfflineMemory<F>>>,
+    pub offline_memory: Arc<Mutex<OfflineMemory<F>>>,
 
     access_adapters: AccessAdapterInventory<F>,
 


### PR DESCRIPTION
In powdr-openvm, we use dummy chips for witgen of autoprecompiles. These chips must access the "real" offline memory. However, in our current set up we cannot do that, since the dummy chips are not part of the vm. This PR makes the offline memory public, so that we can pass the "real" memory to the dummy chips.