### PR TITLE
Add display feature to derive_more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ toml = "0.8.14"
 lazy_static = "1.5.0"
 once_cell = "1.19.0"
 derive-new = "0.6.0"
-derive_more = "1.0.0"
+derive_more = { version = "1.0.0", features = ["display"] }
 derivative = "2.2.0"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }


### PR DESCRIPTION
I don't really know why, but I need this to be able to run `cargo +nightly install --path crates/cli cargo-openvm`.

Before, I would get this error:
```
error[E0433]: failed to resolve: could not find `Display` in `derive_more`
   --> /Users/georg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/alloy-eip7702-0.4.2/src/error.rs:4:30
    |
4   | #[derive(Debug, derive_more::Display, derive_more::From)]
    |                              ^^^^^^^ could not find `Display` in `derive_more`
    |
note: found an item that was configured out
   --> /Users/georg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/derive_more-1.0.0/src/lib.rs:346:13
    |
346 |     Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
    |             ^^^^^^^
note: the item is gated behind the `display` feature
   --> /Users/georg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/derive_more-1.0.0/src/lib.rs:343:7
    |
343 | #[cfg(feature = "display")]
    |       ^^^^^^^^^^^^^^^^^^^

error: cannot find attribute `display` in this scope
 --> /Users/georg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/alloy-eip7702-0.4.2/src/error.rs:7:7
  |
7 |     #[display("invalid signature `s` value: {_0}")]
  |       ^^^^^^^

error[E0277]: `Eip7702Error` doesn't implement `std::fmt::Display`
  --> /Users/georg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/alloy-eip7702-0.4.2/src/error.rs:15:28
   |
15 | impl std::error::Error for Eip7702Error {
   |                            ^^^^^^^^^^^^ `Eip7702Error` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `Eip7702Error`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
note: required by a bound in `std::error::Error`
  --> /rustc/a9730c3b5f84a001c052c60c97ed0765e9ceac04/library/core/src/error.rs:29:1
```