### PR TITLE
Revert "disable bus checks in recursive proofs for now"

### DIFF
--- a/extensions/native/recursion/src/stark/mod.rs
+++ b/extensions/native/recursion/src/stark/mod.rs
@@ -1011,6 +1011,6 @@ fn assert_cumulative_sums<C: Config>(
                         builder.assign(&cumulative_sum, cumulative_sum + summand);
                     });
             });
-        //builder.assert_ext_eq(cumulative_sum, C::EF::ZERO.cons());
+        builder.assert_ext_eq(cumulative_sum, C::EF::ZERO.cons());
     });
 }


### PR DESCRIPTION
This reverts commit edcc227ccb8b9621fe3027000b9673295d9cfe9d.