### PR TITLE
update stark-backend with bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "dacb25f", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "dacb25f", default-features = false }
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "dc01872", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "dc01872", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }


### PR DESCRIPTION
If https://github.com/powdr-labs/powdr/pull/2811 passes we can merge this and use the new hash on the powdr side.