### PR TITLE
Fix OVM Witgen

### DIFF
--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -504,14 +504,14 @@ impl<F: PrimeField32> MemoryController<F> {
                 match &mut state.position {
                     // Reaching the last element of this range, which is the last read/write of an APC range, switch to `OutOfSkipIfUnseen`
                     // Note that we cannot skip the last read/write of an APC range or we get a backend error
-                    Position::SkipIfUnseenUntil(last_rw, _) if index == *last_rw  => {
+                    Position::SkipIfUnseenUntil(last_read_write, _) if index == *last_read_write  => {
                         state.position = Position::OutOfSkipIfUnseen;
                         state.next_range = state.apc_ranges.next();
                     }
                     // Switch to `SkipIfUnseenUntil` iff we reached the start of the next range
                     Position::OutOfSkipIfUnseen => match state.next_range {
-                        Some(ApcRange{ start, end, last_rw  }) if index == *start => {
-                            state.position = Position::SkipIfUnseenUntil((*last_rw).unwrap_or(*end), [false; 32]);
+                        Some(ApcRange { range_start, range_end, last_read_write }) if index == *range_start => {
+                            state.position = Position::SkipIfUnseenUntil((*last_read_write).unwrap_or(*range_end), [false; 32]);
                         }
                         _ => (),
                     },

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -510,7 +510,7 @@ impl<F: PrimeField32> MemoryController<F> {
                     }
                     // Switch to `SkipIfUnseenUntil` iff we reached the start of the next range
                     Position::OutOfSkipIfUnseen => match state.next_range {
-                        Some((start, end, last_rw)) if index == *start => {
+                        Some(ApcRange{ start, end, last_rw  }) if index == *start => {
                             state.position = Position::SkipIfUnseenUntil((*last_rw).unwrap_or(*end), [false; 32]);
                         }
                         _ => (),

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -510,8 +510,8 @@ impl<F: PrimeField32> MemoryController<F> {
                     }
                     // Switch to `SkipIfUnseenUntil` iff we reached the start of the next range
                     Position::OutOfSkipIfUnseen => match state.next_range {
-                        Some((start, _, last_rw)) if index == *start => {
-                            state.position = Position::SkipIfUnseenUntil(*last_rw, [false; 32]);
+                        Some((start, end, last_rw)) if index == *start => {
+                            state.position = Position::SkipIfUnseenUntil((*last_rw).unwrap_or(*end), [false; 32]);
                         }
                         _ => (),
                     },

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -24,7 +24,23 @@ pub enum MemoryLogEntry<T> {
     IncrementTimestampBy(u32),
 }
 
-pub type ApcRange = (usize, usize, Option<usize>); // (range start, memory log length, length from start to last read/write)
+#[derive(Debug)]
+pub struct ApcRange {
+    pub range_start: usize,
+    pub range_end: usize,
+    pub last_read_write: Option<usize>,
+}
+
+// new function for apcrange
+impl ApcRange {
+    pub fn new(range_start: usize, range_end: usize) -> Self {
+        Self {
+            range_start,
+            range_end,
+            last_read_write: None,
+        }
+    }
+}
 
 /// A simple data structure to read to/write from memory.
 ///

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -24,6 +24,8 @@ pub enum MemoryLogEntry<T> {
     IncrementTimestampBy(u32),
 }
 
+pub type ApcRange = (usize, usize, usize); // (range start, memory log length, length from start to last read/write)
+
 /// A simple data structure to read to/write from memory.
 ///
 /// Stores a log of memory accesses to reconstruct aspects of memory state for trace generation.

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -31,13 +31,12 @@ pub struct ApcRange {
     pub last_read_write: Option<usize>,
 }
 
-// new function for apcrange
 impl ApcRange {
-    pub fn new(range_start: usize, range_end: usize) -> Self {
+    pub fn new(range_start: usize, range_end: usize, last_read_write: Option<usize>) -> Self {
         Self {
             range_start,
             range_end,
-            last_read_write: None,
+            last_read_write,
         }
     }
 }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -32,7 +32,7 @@ pub struct Memory<F> {
     pub(super) data: AddressMap<F, PAGE_SIZE>,
     pub(super) log: Vec<MemoryLogEntry<F>>,
     timestamp: u32,
-    pub apc_ranges: Vec<(usize, usize)>,
+    pub apc_ranges: Vec<(usize, usize, usize)>,
 }
 
 impl<F: PrimeField32> Memory<F> {

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -24,7 +24,7 @@ pub enum MemoryLogEntry<T> {
     IncrementTimestampBy(u32),
 }
 
-pub type ApcRange = (usize, usize, usize); // (range start, memory log length, length from start to last read/write)
+pub type ApcRange = (usize, usize, Option<usize>); // (range start, memory log length, length from start to last read/write)
 
 /// A simple data structure to read to/write from memory.
 ///
@@ -34,7 +34,7 @@ pub struct Memory<F> {
     pub(super) data: AddressMap<F, PAGE_SIZE>,
     pub(super) log: Vec<MemoryLogEntry<F>>,
     timestamp: u32,
-    pub apc_ranges: Vec<(usize, usize, usize)>,
+    pub apc_ranges: Vec<ApcRange>,
 }
 
 impl<F: PrimeField32> Memory<F> {


### PR DESCRIPTION
Pair here: https://github.com/powdr-labs/powdr/pull/2836

OVM tests for creating multiple APCs (introduced in PGO branch) fails.

This patches the error that we cannot skip witgen for the last read/write access to memory.

Previously we thought this was the last access, but some APC has timestamp increment as the last access, which is not a "real" access.