### PR TITLE
Optionally increase pc count

### DIFF
--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -35,6 +35,10 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
             );
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InstructionExecutor<F> for #name #ty_generics #where_clause {
+                    fn receives_from_program_chip(&self) -> bool {
+                        self.0.receives_from_program_chip()
+                    }
+
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<F>,

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -79,7 +79,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                 .expect("First generic must be type for Field");
             // Use full path ::openvm_circuit... so it can be used either within or outside the vm
             // crate. Assume F is already generic of the field.
-            let (execute_arms, get_opcode_name_arms): (Vec<_>, Vec<_>) =
+            let (execute_arms, get_opcode_name_arms, receives_from_program_chip_arms): (Vec<_>, Vec<_>, Vec<_>) =
                 multiunzip(variants.iter().map(|(variant_name, field)| {
                     let field_ty = &field.ty;
                     let execute_arm = quote! {
@@ -88,11 +88,20 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     let get_opcode_name_arm = quote! {
                         #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::get_opcode_name(x, opcode)
                     };
+                    let receives_from_program_chip_arm = quote! {
+                        #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::receives_from_program_chip(x)
+                    };
 
-                    (execute_arm, get_opcode_name_arm)
+                    (execute_arm, get_opcode_name_arm, receives_from_program_chip_arm)
                 }));
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic> for #name #ty_generics {
+                    fn receives_from_program_chip(&self) -> bool {
+                        match self {
+                            #(#receives_from_program_chip_arms,)*
+                        }
+                    }
+
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<#first_ty_generic>,

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -70,6 +70,9 @@ pub enum ExecutionError {
 }
 
 pub trait InstructionExecutor<F> {
+    /// Whether this instruction receives from the program chip.
+    const RECEIVES_FROM_PROGRAM_CHIP: bool = true;
+
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
     fn execute(

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -70,8 +70,10 @@ pub enum ExecutionError {
 }
 
 pub trait InstructionExecutor<F> {
-    /// Whether this instruction receives from the program chip.
-    const RECEIVES_FROM_PROGRAM_CHIP: bool = true;
+    /// Whether this instruction receives from the program chip
+    fn receives_from_program_chip(&self) -> bool {
+        true
+    }
 
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
@@ -88,6 +90,10 @@ pub trait InstructionExecutor<F> {
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
+    fn receives_from_program_chip(&self) -> bool {
+        self.borrow().receives_from_program_chip()
+    }
+
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
@@ -103,6 +109,10 @@ impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
+    fn receives_from_program_chip(&self) -> bool {
+        self.borrow().receives_from_program_chip()
+    }
+
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -241,7 +241,7 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
                 } = &mut chip_complex.base;
 
                 let (instruction, debug_info) =
-                    program_chip.get_instruction(pc, Some(&chip_complex.inventory))?;
+                    program_chip.get_instruction_and_maybe_increase_count(pc, &chip_complex.inventory)?;
                 // tracing::trace!("pc: {pc:#x} | time: {timestamp} | {:?}", instruction);
                 // update the trace event for logging instructions in execution order in our profiler via a custom subscriber
                 tracing::trace!(pc = pc, "executing instruction");

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -240,7 +240,8 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
                     ..
                 } = &mut chip_complex.base;
 
-                let (instruction, debug_info) = program_chip.get_instruction(pc)?;
+                let (instruction, debug_info) =
+                    program_chip.get_instruction(pc, Some(&chip_complex.inventory))?;
                 // tracing::trace!("pc: {pc:#x} | time: {timestamp} | {:?}", instruction);
                 // update the trace event for logging instructions in execution order in our profiler via a custom subscriber
                 tracing::trace!(pc = pc, "executing instruction");

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -106,15 +106,12 @@ impl<F: PrimeField64> ProgramChip<F> {
 
         let instruction = &res.0;
 
-        if let Some(executor) = inventory.get_executor(instruction.opcode) {
-            if executor.receives_from_program_chip() {
-                // If the executor receives from the program chip, we need to update the frequency in the program chip
-                self.execution_frequencies[pc_index] += 1;
-            } else {
-                panic!();
-            }
-        } else {
-            panic!();
+        // Iff the executor receives from the program chip or we don't have an executor for this opcode (system opcode), we increase the frequency count.
+        if inventory
+            .get_executor(instruction.opcode)
+            .map_or(true, |executor| executor.receives_from_program_chip())
+        {
+            self.execution_frequencies[pc_index] += 1;
         }
         Ok(res)
     }

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -91,8 +91,8 @@ impl<F: PrimeField64> ProgramChip<F> {
         let instruction = &res.0;
 
         if let Some(inventory) = inventory {
-            if let Some(_) = inventory.get_executor(instruction.opcode) {
-                if E::RECEIVES_FROM_PROGRAM_CHIP {
+            if let Some(executor) = inventory.get_executor(instruction.opcode) {
+                if executor.receives_from_program_chip() {
                     // If the executor receives from the program chip, we need to update the frequency in the program chip
                     self.execution_frequencies[pc_index] += 1;
                 }

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -95,6 +95,8 @@ impl<F: PrimeField64> ProgramChip<F> {
                 if executor.receives_from_program_chip() {
                     // If the executor receives from the program chip, we need to update the frequency in the program chip
                     self.execution_frequencies[pc_index] += 1;
+                } else {
+                    panic!();
                 }
             }
         }

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -113,6 +113,8 @@ impl<F: PrimeField64> ProgramChip<F> {
             } else {
                 panic!();
             }
+        } else {
+            panic!();
         }
         Ok(res)
     }

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -37,11 +37,11 @@ assert_impl_all!(VmCommittedExe<BabyBearPoseidon2RootConfig>: Serialize, Deseria
 
 fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let bus = ProgramBus::new(READ_INSTRUCTION_BUS);
-    let mut chip = ProgramChip::new_with_program(program.clone(), bus);
+    let chip = ProgramChip::new_with_program(program.clone(), bus);
     let mut execution_frequencies = vec![0; program.len()];
     for pc_idx in execution {
         execution_frequencies[pc_idx as usize] += 1;
-        chip.get_instruction(pc_idx * DEFAULT_PC_STEP, None).unwrap();
+        chip.get_instruction(pc_idx * DEFAULT_PC_STEP).unwrap();
     }
     let program_air = chip.air;
     let program_proof_input = chip.generate_air_proof_input(None);
@@ -179,10 +179,10 @@ fn test_program_negative() {
     let bus = ProgramBus::new(READ_INSTRUCTION_BUS);
     let program = Program::from_instructions(&instructions);
 
-    let mut chip = ProgramChip::new_with_program(program, bus);
+    let chip = ProgramChip::new_with_program(program, bus);
     let execution_frequencies = vec![1; instructions.len()];
     for pc_idx in 0..instructions.len() {
-        chip.get_instruction(pc_idx as u32 * DEFAULT_PC_STEP, None)
+        chip.get_instruction(pc_idx as u32 * DEFAULT_PC_STEP)
             .unwrap();
     }
     let program_air = chip.air;

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -41,7 +41,7 @@ fn interaction_test(program: Program<BabyBear>, execution: Vec<u32>) {
     let mut execution_frequencies = vec![0; program.len()];
     for pc_idx in execution {
         execution_frequencies[pc_idx as usize] += 1;
-        chip.get_instruction(pc_idx * DEFAULT_PC_STEP).unwrap();
+        chip.get_instruction(pc_idx * DEFAULT_PC_STEP, None).unwrap();
     }
     let program_air = chip.air;
     let program_proof_input = chip.generate_air_proof_input(None);
@@ -182,7 +182,7 @@ fn test_program_negative() {
     let mut chip = ProgramChip::new_with_program(program, bus);
     let execution_frequencies = vec![1; instructions.len()];
     for pc_idx in 0..instructions.len() {
-        chip.get_instruction(pc_idx as u32 * DEFAULT_PC_STEP)
+        chip.get_instruction(pc_idx as u32 * DEFAULT_PC_STEP, None)
             .unwrap();
     }
     let program_air = chip.air;


### PR DESCRIPTION
We want to be able not to receive the program line from the program chip.
Define this in the `InstructionExecutor` trait. Default to true.
The inventory input is optional because some tests do not have it.