### PR TITLE
Add apc opcodes to program for witgen

### DIFF
--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -1,10 +1,10 @@
-use std::{fmt, fmt::Display};
+use std::{collections::HashMap, fmt::{self, Display}};
 
 use itertools::Itertools;
 use openvm_stark_backend::p3_field::Field;
 use serde::{de::Deserializer, Deserialize, Serialize, Serializer};
 
-use crate::instruction::{DebugInfo, Instruction};
+use crate::{instruction::{DebugInfo, Instruction}, VmOpcode};
 
 pub const PC_BITS: usize = 30;
 /// We use default PC step of 4 whenever possible for consistency with RISC-V, where 4 comes
@@ -24,6 +24,7 @@ pub struct Program<F> {
         deserialize_with = "deserialize_instructions_and_debug_infos"
     )]
     pub instructions_and_debug_infos: Vec<Option<(Instruction<F>, Option<DebugInfo>)>>,
+    pub apc_by_pc_index: HashMap<usize, (Instruction<F>, Option<DebugInfo>)>, 
     pub step: u32,
     pub pc_base: u32,
 }
@@ -32,6 +33,7 @@ impl<F: Field> Program<F> {
     pub fn new_empty(step: u32, pc_base: u32) -> Self {
         Self {
             instructions_and_debug_infos: vec![],
+            apc_by_pc_index: HashMap::new(),
             step,
             pc_base,
         }
@@ -47,6 +49,7 @@ impl<F: Field> Program<F> {
                 .iter()
                 .map(|instruction| Some((instruction.clone(), None)))
                 .collect(),
+            apc_by_pc_index: HashMap::new(),
             step,
             pc_base,
         }
@@ -62,9 +65,17 @@ impl<F: Field> Program<F> {
                 .iter()
                 .map(|instruction| instruction.clone().map(|instruction| (instruction, None)))
                 .collect(),
+            apc_by_pc_index: HashMap::new(),
             step,
             pc_base,
         }
+    }
+
+    pub fn add_apc_instruction_at_pc_index(&mut self, pc_index: usize, opcode: VmOpcode) {
+        let debug: Option<DebugInfo> = self.instructions_and_debug_infos
+            [pc_index].as_ref().unwrap().1.clone();
+
+        self.apc_by_pc_index.insert(pc_index, (Instruction::from_usize(opcode, []), debug));
     }
 
     /// We assume that pc_start = pc_base = 0 everywhere except the RISC-V programs, until we need
@@ -79,6 +90,7 @@ impl<F: Field> Program<F> {
                 .zip_eq(debug_infos.iter())
                 .map(|(instruction, debug_info)| Some((instruction.clone(), debug_info.clone())))
                 .collect(),
+            apc_by_pc_index: HashMap::new(),
             step: DEFAULT_PC_STEP,
             pc_base: 0,
         }
@@ -170,6 +182,11 @@ impl<F: Field> Program<F> {
     pub fn append(&mut self, other: Program<F>) {
         self.instructions_and_debug_infos
             .extend(other.instructions_and_debug_infos);
+    }
+    
+    pub fn get_apc_instruction(&self, pc_index: usize) -> Option<&(Instruction<F>, Option<DebugInfo>)> {
+        self.apc_by_pc_index.get(&pc_index)
+
     }
 }
 impl<F: Field> Display for Program<F> {

--- a/crates/vm/derive/src/lib.rs
+++ b/crates/vm/derive/src/lib.rs
@@ -35,10 +35,6 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
             );
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InstructionExecutor<F> for #name #ty_generics #where_clause {
-                    fn receives_from_program_chip(&self) -> bool {
-                        self.0.receives_from_program_chip()
-                    }
-
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<F>,
@@ -79,7 +75,7 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                 .expect("First generic must be type for Field");
             // Use full path ::openvm_circuit... so it can be used either within or outside the vm
             // crate. Assume F is already generic of the field.
-            let (execute_arms, get_opcode_name_arms, receives_from_program_chip_arms): (Vec<_>, Vec<_>, Vec<_>) =
+            let (execute_arms, get_opcode_name_arms): (Vec<_>, Vec<_>) =
                 multiunzip(variants.iter().map(|(variant_name, field)| {
                     let field_ty = &field.ty;
                     let execute_arm = quote! {
@@ -88,20 +84,11 @@ pub fn instruction_executor_derive(input: TokenStream) -> TokenStream {
                     let get_opcode_name_arm = quote! {
                         #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::get_opcode_name(x, opcode)
                     };
-                    let receives_from_program_chip_arm = quote! {
-                        #name::#variant_name(x) => <#field_ty as ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic>>::receives_from_program_chip(x)
-                    };
 
-                    (execute_arm, get_opcode_name_arm, receives_from_program_chip_arm)
+                    (execute_arm, get_opcode_name_arm)
                 }));
             quote! {
                 impl #impl_generics ::openvm_circuit::arch::InstructionExecutor<#first_ty_generic> for #name #ty_generics {
-                    fn receives_from_program_chip(&self) -> bool {
-                        match self {
-                            #(#receives_from_program_chip_arms,)*
-                        }
-                    }
-
                     fn execute(
                         &mut self,
                         memory: &mut ::openvm_circuit::system::memory::MemoryController<#first_ty_generic>,

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -70,11 +70,6 @@ pub enum ExecutionError {
 }
 
 pub trait InstructionExecutor<F> {
-    /// Whether this instruction receives from the program chip
-    fn receives_from_program_chip(&self) -> bool {
-        true
-    }
-
     /// Runtime execution of the instruction, if the instruction is owned by the
     /// current instance. May internally store records of this call for later trace generation.
     fn execute(
@@ -90,10 +85,6 @@ pub trait InstructionExecutor<F> {
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
-    fn receives_from_program_chip(&self) -> bool {
-        self.borrow().receives_from_program_chip()
-    }
-
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,
@@ -109,10 +100,6 @@ impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for RefCell<C> {
 }
 
 impl<F, C: InstructionExecutor<F>> InstructionExecutor<F> for Rc<RefCell<C>> {
-    fn receives_from_program_chip(&self) -> bool {
-        self.borrow().receives_from_program_chip()
-    }
-
     fn execute(
         &mut self,
         memory: &mut MemoryController<F>,

--- a/crates/vm/src/arch/segment.rs
+++ b/crates/vm/src/arch/segment.rs
@@ -241,7 +241,7 @@ impl<F: PrimeField32, VC: VmConfig<F>> ExecutionSegment<F, VC> {
                 } = &mut chip_complex.base;
 
                 let (instruction, debug_info) =
-                    program_chip.get_instruction_and_maybe_increase_count(pc, &chip_complex.inventory)?;
+                    program_chip.get_instruction_and_maybe_increase_count(pc)?;
                 // tracing::trace!("pc: {pc:#x} | time: {timestamp} | {:?}", instruction);
                 // update the trace event for logging instructions in execution order in our profiler via a custom subscriber
                 tracing::trace!(pc = pc, "executing instruction");

--- a/crates/vm/src/system/program/mod.rs
+++ b/crates/vm/src/system/program/mod.rs
@@ -99,7 +99,7 @@ impl<F: PrimeField64> ProgramChip<F> {
             return Ok(res);
         }
 
-        self
+        let res = self
             .program
             .get_instruction_and_debug_info(pc_index)
             .ok_or(ExecutionError::PcNotFound {
@@ -107,7 +107,12 @@ impl<F: PrimeField64> ProgramChip<F> {
                 step: self.program.step,
                 pc_base: self.program.pc_base,
                 program_len: self.program.len(),
-            })
+            })?;
+        
+        // Increase the execution frequency for this instruction.
+        self.execution_frequencies[pc_index] += 1;
+
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
After this PR, the prover always chooses to execute apcs instead of the software version for the passed pc indices.