### PR TITLE
OVM 11.16 update

### DIFF
--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build benchmarks
         working-directory: benchmarks/execute
-        run: cargo $TOOLCHAIN codspeed build --features tco
+        run: cargo $TOOLCHAIN codspeed build --features tco --bench execute
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:

--- a/.github/workflows/benchmarks-execute.yml
+++ b/.github/workflows/benchmarks-execute.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build benchmarks
         working-directory: benchmarks/execute
-        run: cargo $TOOLCHAIN codspeed build --profile maxperf --features tco
+        run: cargo $TOOLCHAIN codspeed build --profile maxperf --features tco --bench execute
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Install solc # svm should support arm64 linux
         run: |
-          (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+          (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Install cargo-openvm
         working-directory: crates/cli

--- a/.github/workflows/recursion.yml
+++ b/.github/workflows/recursion.yml
@@ -36,7 +36,7 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Install solc # svm should support arm64 linux
-        run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+        run: (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Run recursion crate tests
         working-directory: extensions/native/recursion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "version=${{ github.event.inputs.version || 'v1.4.1' }}" >> $GITHUB_ENV
 
       - name: Install solc # svm should support arm64 linux
-        run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+        run: (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -40,7 +40,7 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Install solc # svm should support arm64 linux
-        run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+        run: (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "version=${{ github.event.inputs.version || 'v1.4.1' }}" >> $GITHUB_ENV
 
       - name: Install solc # svm should support arm64 linux
-        run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
+        run: (hash svm 2>/dev/null || cargo install --locked --version 0.2.23 svm-rs) && svm install 0.8.19 && solc --version
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/crates/sdk/src/prover/app.rs
+++ b/crates/sdk/src/prover/app.rs
@@ -254,6 +254,7 @@ pub fn verify_app_proof(
 #[cfg(feature = "async")]
 mod async_prover {
     use derivative::Derivative;
+    use eyre::eyre;
     use openvm_circuit::{
         arch::ExecutionError, system::memory::merkle::public_values::UserPublicValuesProof,
     };
@@ -376,10 +377,8 @@ mod async_prover {
             drop(metered_interpreter);
             let pure_interpreter = vm.interpreter(&self.app_exe)?;
             let mut tasks = Vec::with_capacity(segments.len());
-            let terminal_instret = segments
-                .last()
-                .map(|s| s.instret_start + s.num_insns)
-                .unwrap_or(u64::MAX);
+            let user_pv_proof: Arc<OnceLock<UserPublicValuesProof<CHUNK, Val<E::SC>>>> =
+                Arc::new(OnceLock::new());
             for (seg_idx, segment) in segments.into_iter().enumerate() {
                 tracing::info!(
                     %seg_idx,
@@ -394,6 +393,7 @@ mod async_prover {
                 let semaphore = self.semaphore.clone();
                 let async_worker = self.clone();
                 let start_state = state.clone();
+                let user_pv_proof = user_pv_proof.clone();
                 let task = spawn(
                     async move {
                         let _permit = semaphore.acquire().await?;
@@ -414,12 +414,25 @@ mod async_prover {
                                     let instance = &mut worker.instance;
                                     let vm = &mut instance.vm;
                                     let preflight_interpreter = &mut instance.interpreter;
-                                    let (segment_proof, _) = vm.prove(
+                                    let (segment_proof, final_memory) = vm.prove(
                                         preflight_interpreter,
                                         start_state,
                                         Some(segment.num_insns),
                                         &segment.trace_heights,
                                     )?;
+                                    if let Some(final_memory) = final_memory {
+                                        let top_tree = vm.memory_top_tree().unwrap();
+                                        let proof = UserPublicValuesProof::compute(
+                                            vm.config().as_ref().memory_config.memory_dimensions(),
+                                            vm.config().as_ref().num_public_values,
+                                            &vm_poseidon2_hasher(),
+                                            &final_memory.memory,
+                                            top_tree,
+                                        );
+                                        user_pv_proof.set(proof).map_err(|_| {
+                                            eyre!("Only one segment should be terminal")
+                                        })?;
+                                    }
                                     Ok(segment_proof)
                                 },
                             )
@@ -430,30 +443,16 @@ mod async_prover {
                 );
                 tasks.push(task);
             }
-            // Finish execution to termination
-            state = pure_interpreter.execute_from_state(state, None)?;
-            if state.instret() != terminal_instret {
-                tracing::warn!(
-                    "Pure execution terminal instret={}, metered execution terminal instret={}",
-                    state.instret(),
-                    terminal_instret
-                );
-                // This should never happen
-                return Err(ExecutionError::DidNotTerminate.into());
-            }
-            let final_memory = &state.memory.memory;
-            let user_public_values = UserPublicValuesProof::compute(
-                vm.config().as_ref().memory_config.memory_dimensions(),
-                vm.config().as_ref().num_public_values,
-                &vm_poseidon2_hasher(),
-                final_memory,
-            );
 
             let mut proofs = Vec::with_capacity(tasks.len());
             for task in tasks {
                 let proof = task.await??;
                 proofs.push(proof);
             }
+            let user_public_values = user_pv_proof
+                .get()
+                .ok_or(ExecutionError::DidNotTerminate)?
+                .clone();
             let cont_proof = ContinuationVmProof {
                 per_segment: proofs,
                 user_public_values,

--- a/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/segment_ctx.rs
@@ -191,10 +191,10 @@ impl SegmentationCtx {
                 tracing::info!(
                     "instret {:10} | height ({:8}) > max ({:8}) | chip {:3} ({}) ",
                     instret,
+                    padded_height,
+                    self.segmentation_limits.max_trace_height,
                     i,
                     air_name,
-                    padded_height,
-                    self.segmentation_limits.max_trace_height
                 );
                 return true;
             }
@@ -262,9 +262,15 @@ impl SegmentationCtx {
                 self.checkpoint_trace_heights.clone(),
             )
         } else {
+            let trace_heights_str = trace_heights
+                .iter()
+                .zip(self.air_names.iter())
+                .filter(|(&height, _)| height > 0)
+                .map(|(&height, name)| format!("  {} = {}", name, height))
+                .collect::<Vec<_>>()
+                .join("\n");
             tracing::warn!(
-                "No valid checkpoint, creating segment using instret={instret}, trace_heights={:?}",
-                trace_heights
+                "No valid checkpoint, creating segment using instret={instret}\ntrace_heights=[\n{trace_heights_str}\n]"
             );
             // No valid checkpoint, use current values
             (instret, trace_heights.to_vec())

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -772,6 +772,11 @@ where
             .transport_init_memory_to_device(memory);
     }
 
+    /// See [`SystemChipComplex::memory_top_tree`].
+    pub fn memory_top_tree(&self) -> Option<&[[Val<E::SC>; CHUNK]]> {
+        self.chip_complex.system.memory_top_tree()
+    }
+
     pub fn executor_idx_to_air_idx(&self) -> Vec<usize> {
         let ret = self.chip_complex.inventory.executor_idx_to_air_idx();
         tracing::debug!("executor_idx_to_air_idx: {:?}", ret);
@@ -1021,11 +1026,13 @@ where
         }
         let to_state = state.unwrap();
         let final_memory = &to_state.memory.memory;
+        let final_memory_top_tree = vm.memory_top_tree().expect("memory top tree should exist");
         let user_public_values = UserPublicValuesProof::compute(
             vm.config().as_ref().memory_config.memory_dimensions(),
             vm.config().as_ref().num_public_values,
             &vm_poseidon2_hasher(),
             final_memory,
+            final_memory_top_tree,
         );
         self.state = Some(to_state);
         Ok(ContinuationVmProof {

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -138,7 +138,7 @@ impl MemoryInventoryGPU {
             TouchedMemory::Persistent(partition) => {
                 let persistent = self
                     .persistent
-                    .as_ref()
+                    .as_mut()
                     .expect("persistent touched memory requires persistent memory interface");
 
                 let unpadded_merkle_height =

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -195,6 +195,7 @@ pub struct MemoryMerkleTree {
     pub height: usize,
     pub hasher_buffer: SharedBuffer<F>,
     mem_config: MemoryConfig,
+    pub(crate) top_roots_host: Vec<H>,
 }
 
 impl MemoryMerkleTree {
@@ -242,6 +243,7 @@ impl MemoryMerkleTree {
             zero_hash,
             hasher_buffer: hasher_chip.shared_buffer(),
             mem_config,
+            top_roots_host: vec![],
         }
     }
 
@@ -318,7 +320,7 @@ impl MemoryMerkleTree {
 
     /// Updates the tree and returns the merkle trace.
     pub fn update_with_touched_blocks(
-        &self,
+        &mut self,
         unpadded_height: usize,
         d_touched_blocks: &DeviceBuffer<u32>, // consists of (as, label, ts, [F; 8])
         empty_touched_blocks: bool,
@@ -367,7 +369,8 @@ impl MemoryMerkleTree {
                 output
             }
         };
-        public_values.extend(self.top_roots.to_host().unwrap()[0].to_vec());
+        self.top_roots_host = self.top_roots.to_host().unwrap();
+        public_values.extend(self.top_roots_host[0]);
 
         AirProvingContext::new(Vec::new(), Some(merkle_trace), public_values)
     }

--- a/crates/vm/src/system/cuda/mod.rs
+++ b/crates/vm/src/system/cuda/mod.rs
@@ -21,6 +21,8 @@ use poseidon2::Poseidon2PeripheryChipGPU;
 use program::ProgramChipGPU;
 use public_values::PublicValuesChipGPU;
 
+use crate::system::memory::CHUNK;
+
 pub(crate) const DIGEST_WIDTH: usize = 8;
 
 pub mod access_adapters;
@@ -138,6 +140,16 @@ impl SystemChipComplex<DenseRecordArena, GpuBackend> for SystemChipInventoryGPU 
             .chain(pv_ctx)
             .chain(memory_ctxs)
             .collect()
+    }
+
+    fn memory_top_tree(&self) -> Option<&[[F; CHUNK]]> {
+        self.memory_inventory
+            .persistent
+            .as_ref()
+            .and_then(|persistent| {
+                let top_tree = &persistent.merkle_tree.top_roots_host;
+                (!top_tree.is_empty()).then_some(top_tree.as_slice())
+            })
     }
 
     #[cfg(feature = "metrics")]

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -28,6 +28,7 @@ pub struct MemoryMerkleChip<const CHUNK: usize, F> {
     pub air: MemoryMerkleAir<CHUNK>,
     final_state: Option<FinalState<CHUNK, F>>,
     overridden_height: Option<usize>,
+    pub(crate) top_tree: Vec<[F; CHUNK]>,
     /// Used for metric collection purposes only
     #[cfg(feature = "metrics")]
     pub(crate) current_height: usize,
@@ -57,6 +58,7 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
             },
             final_state: None,
             overridden_height: None,
+            top_tree: vec![],
             #[cfg(feature = "metrics")]
             current_height: 0,
         }

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -35,8 +35,10 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
         hasher: &impl HasherChip<CHUNK, F>,
     ) {
         assert!(self.final_state.is_none(), "Merkle chip already finalized");
-        let mut tree = MerkleTree::from_memory(initial_memory, &self.air.memory_dimensions, hasher);
-        self.final_state = Some(tree.finalize(hasher, final_memory, &self.air.memory_dimensions));
+        let memory_dimensions = &self.air.memory_dimensions;
+        let mut tree = MerkleTree::from_memory(initial_memory, memory_dimensions, hasher);
+        self.final_state = Some(tree.finalize(hasher, final_memory, memory_dimensions));
+        self.top_tree = tree.top_tree(memory_dimensions.addr_space_height);
     }
 }
 

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -264,4 +264,11 @@ impl<F: PrimeField32, const CHUNK: usize> MerkleTree<F, CHUNK> {
             final_root,
         }
     }
+
+    pub fn top_tree(&self, top_height: usize) -> Vec<[F; CHUNK]> {
+        // tree root is at index 1
+        (0..(2 << top_height) - 1)
+            .map(|i| self.get_node(i + 1))
+            .collect()
+    }
 }


### PR DESCRIPTION
How we get here:
1. Start from `1.4.1-upgrade` branch, which is identical to `v1.4.1-powdr` tag, which has latest commit 60073d7908e703ba585475a285f7a4c6eadd9853.
2. Merge over OVM main, which has latest commit https://github.com/openvm-org/openvm/commit/7e9488992a74d49fa697359681cd2a7e768b90ef.
3. No merge conflict.