### PR TITLE
Update stark-backend tag to add AIR IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -6440,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "cc",
  "glob",
@@ -6449,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bytesize",
  "ctor",
@@ -7202,7 +7202,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.2.2"
-source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr#c5e930ebe878735811dd8d1437559171030808e5"
+source = "git+https://github.com/powdr-labs/stark-backend.git?rev=v1.2.2-powdr-2026-03-20#e7b9f31b70acd03e474739d7506285a2709a7ed1"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,11 +113,11 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
-openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr", default-features = false }
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
+openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "v1.2.2-powdr-2026-03-20", default-features = false }
 
 # OpenVM
 openvm-sdk = { path = "crates/sdk", default-features = false }
@@ -189,7 +189,10 @@ p3-poseidon2-air = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539b
 p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "539bbc84085efb609f4f62cb03cf49588388abdb", default-features = false }
 
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }
-snark-verifier-sdk = { version = "0.2.0", default-features = false, features = ["loader_halo2", "halo2-axiom"] }
+snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [
+    "loader_halo2",
+    "halo2-axiom",
+] }
 snark-verifier = { version = "0.2.0", default-features = false }
 halo2curves-axiom = { git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
 struct-reflection = { git = "https://github.com/gzanitti/struct-reflection-rs.git" }
@@ -205,7 +208,9 @@ clap = "4.5.23"
 toml = "0.8.14"
 lazy_static = "1.5.0"
 derive-new = "0.6.0"
-derive_more = { version = "1.0.0", features = ["display"], default-features = false }
+derive_more = { version = "1.0.0", features = [
+    "display",
+], default-features = false }
 derivative = "2.2.0"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -59,10 +59,12 @@ __global__ void cukernel_persistent_boundary_tracegen(
         COL_WRITE_VALUE(row, PersistentBoundaryCols, leaf_label, record.ptr / PERSISTENT_CHUNK);
         if (row_idx % 2 == 0) {
             // TODO better address space handling
+            // Address spaces 4 (PUBLIC_VALUES_AS) and 5+ use native32 cell type (field elements).
+            // Address spaces 1-3 use U8 cell type (bytes).
             FpArray<8> init_values;
             if (initial_mem[record.address_space - 1]) {
-                init_values = 
-                    record.address_space == 4
+                init_values =
+                    record.address_space >= 4
                         ? FpArray<8>::from_raw_array(
                             reinterpret_cast<uint32_t const *>(
                                 initial_mem[record.address_space - 1]

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -484,6 +484,9 @@ extern "C" int _build_merkle_subtree(
         case 3:
             merkle_tree_init<3><<<grid, block, 0, stream>>>(data, tree + (size - 1));
             break;
+        case 4:
+            merkle_tree_init<4><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+            break;
         default:
             return -1;
         }


### PR DESCRIPTION
To benefit from https://github.com/powdr-labs/stark-backend/pull/20, I pushed a new stark-backend tag `v1.2.2-powdr-2026-03-20`. The last commit in this PR updates the tag.

The other two commits were already used by the `v1.4.2-powdr-rc.3` tag currently used on powdr main:
https://github.com/powdr-labs/openvm/commits/v1.4.2-powdr-rc.3/

So I think they should also be on the `v1.4.2-upgrade` branch.