### PR TITLE
Add benchmark for proving time vs AIR complexity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6053,6 +6053,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-benchmark-air-complexity"
+version = "2.0.0-alpha"
+dependencies = [
+ "clap",
+ "eyre",
+ "openvm-benchmark-circuit",
+ "openvm-circuit",
+ "openvm-instructions",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+]
+
+[[package]]
+name = "openvm-benchmark-circuit"
+version = "2.0.0-alpha"
+dependencies = [
+ "derive-new 0.6.0",
+ "derive_more 1.0.0",
+ "openvm-circuit",
+ "openvm-circuit-derive",
+ "openvm-circuit-primitives",
+ "openvm-circuit-primitives-derive",
+ "openvm-cpu-backend",
+ "openvm-instructions",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
 name = "openvm-benchmarks-execute"
 version = "2.0.0-alpha"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "benchmarks/utils",
     "benchmarks/execute",
     "benchmarks/prove",
+    "benchmarks/air-complexity",
     "crates/prof",
     "crates/cli",
     "crates/sdk",
@@ -63,6 +64,7 @@ members = [
     "extensions/ecc/tests",
     "extensions/pairing/circuit",
     "extensions/pairing/guest",
+    "extensions/benchmark/circuit",
     "guest-libs/ff_derive/",
     "guest-libs/k256/",
     "guest-libs/p256/",
@@ -182,6 +184,7 @@ openvm-verify-stark-guest = { path = "guest-libs/verify-stark/guest", default-fe
 openvm-deferral-circuit = { path = "extensions/deferral/circuit", default-features = false }
 openvm-deferral-guest = { path = "extensions/deferral/guest", default-features = false }
 openvm-deferral-transpiler = { path = "extensions/deferral/transpiler", default-features = false }
+openvm-benchmark-circuit = { path = "extensions/benchmark/circuit", default-features = false }
 
 # Benchmarking
 openvm-benchmarks-utils = { path = "benchmarks/utils", default-features = false }

--- a/benchmarks/air-complexity/Cargo.toml
+++ b/benchmarks/air-complexity/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "openvm-benchmark-air-complexity"
+description = "Benchmark proving time vs AIR complexity parameters"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "benchmark_air"
+path = "src/main.rs"
+
+[dependencies]
+openvm-benchmark-circuit.workspace = true
+openvm-circuit = { workspace = true, features = ["test-utils"] }
+openvm-instructions.workspace = true
+openvm-stark-backend.workspace = true
+openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
+
+clap = { workspace = true, features = ["derive"] }
+eyre.workspace = true
+
+[features]
+default = ["parallel", "jemalloc"]
+jemalloc = ["openvm-circuit/jemalloc"]
+parallel = ["openvm-circuit/parallel"]

--- a/benchmarks/air-complexity/src/main.rs
+++ b/benchmarks/air-complexity/src/main.rs
@@ -1,0 +1,153 @@
+use std::time::Instant;
+
+use clap::Parser;
+use openvm_benchmark_circuit::{
+    BenchmarkCpuBuilder, BenchmarkExtension, BenchmarkVmConfig, BENCHMARK_OPCODE_BASE,
+};
+use openvm_circuit::arch::{instructions::exe::VmExe, SystemConfig};
+use openvm_circuit::utils::{air_test_impl, TestStarkEngine};
+use openvm_instructions::{
+    instruction::Instruction, program::Program, LocalOpcode, SystemOpcode::TERMINATE, VmOpcode,
+};
+use openvm_stark_backend::SystemParams;
+use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+type F = BabyBear;
+
+#[derive(Parser, Debug)]
+#[command(about = "Benchmark proving time vs AIR complexity parameters")]
+struct Cli {
+    /// Number of distinct benchmark AIRs
+    #[arg(long, default_value = "1")]
+    num_airs: usize,
+
+    /// Number of columns per AIR (including structural columns)
+    #[arg(long, default_value = "64")]
+    cols_per_air: usize,
+
+    /// Number of boolean constraints per AIR
+    #[arg(long, default_value = "32")]
+    constraints_per_air: usize,
+
+    /// Number of range check interactions per row per AIR
+    #[arg(long, default_value = "4")]
+    interactions_per_air: usize,
+
+    /// Number of trace rows consumed per precompile invocation
+    #[arg(long, default_value = "64")]
+    rows_per_invocation: usize,
+
+    /// Total trace cells across all benchmark AIRs (num_airs * trace_height * cols_per_air)
+    #[arg(long, default_value = "4194304")]
+    total_cells: usize,
+}
+
+fn main() -> eyre::Result<()> {
+    let cli = Cli::parse();
+
+    // Validate and compute derived parameters
+    assert!(
+        cli.cols_per_air >= 7,
+        "cols_per_air must be >= 7 (6 structural + at least 1 payload)"
+    );
+    assert!(cli.num_airs > 0, "num_airs must be > 0");
+    assert!(
+        cli.rows_per_invocation > 0,
+        "rows_per_invocation must be > 0"
+    );
+
+    let trace_height_per_air = cli.total_cells / (cli.num_airs * cli.cols_per_air);
+    assert!(
+        trace_height_per_air > 0,
+        "total_cells too small for given num_airs and cols_per_air"
+    );
+    assert!(
+        trace_height_per_air % cli.rows_per_invocation == 0,
+        "trace_height_per_air ({trace_height_per_air}) must be divisible by rows_per_invocation ({})",
+        cli.rows_per_invocation,
+    );
+
+    let invocations_per_air = trace_height_per_air / cli.rows_per_invocation;
+    let total_invocations = invocations_per_air * cli.num_airs;
+    let padded_height = trace_height_per_air.next_power_of_two();
+
+    eprintln!("=== Benchmark AIR Complexity ===");
+    eprintln!("  num_airs:             {}", cli.num_airs);
+    eprintln!("  cols_per_air:         {}", cli.cols_per_air);
+    eprintln!("  constraints_per_air:  {}", cli.constraints_per_air);
+    eprintln!("  interactions_per_air: {}", cli.interactions_per_air);
+    eprintln!("  rows_per_invocation:  {}", cli.rows_per_invocation);
+    eprintln!("  total_cells:          {}", cli.total_cells);
+    eprintln!("  ---");
+    eprintln!(
+        "  trace_height_per_air: {} (padded: {})",
+        trace_height_per_air, padded_height
+    );
+    eprintln!("  invocations_per_air:  {}", invocations_per_air);
+    eprintln!("  total_instructions:   {}", total_invocations + 1);
+    eprintln!();
+
+    // Build extension and config
+    let ext = BenchmarkExtension {
+        num_airs: cli.num_airs,
+        cols_per_air: cli.cols_per_air,
+        constraints_per_air: cli.constraints_per_air,
+        interactions_per_air: cli.interactions_per_air,
+        rows_per_invocation: cli.rows_per_invocation,
+    };
+    let config = BenchmarkVmConfig {
+        system: SystemConfig::default().with_max_segment_len(padded_height),
+        benchmark: ext,
+    };
+
+    // Construct flat instruction sequence
+    let mut instructions: Vec<Instruction<F>> = Vec::with_capacity(total_invocations + 1);
+    for _ in 0..invocations_per_air {
+        for air_idx in 0..cli.num_airs {
+            instructions.push(Instruction::from_isize(
+                VmOpcode::from_usize(BENCHMARK_OPCODE_BASE + air_idx),
+                0,
+                0,
+                0,
+                0,
+                0,
+            ));
+        }
+    }
+    instructions.push(Instruction::from_isize(
+        TERMINATE.global_opcode(),
+        0,
+        0,
+        0,
+        0,
+        0,
+    ));
+
+    let program = Program::from_instructions(&instructions);
+    let exe = VmExe::new(program);
+
+    // Run proving pipeline with timing
+    // Use at least 22 as the max log trace height (same as air_test), since system chips
+    // like VariableRangeChecker may have large traces independent of our benchmark.
+    let log_max_height = (padded_height.ilog2() as usize + 1).max(22);
+    let params = SystemParams::new_for_testing(log_max_height);
+
+    let total_start = Instant::now();
+    let (_final_memory, proofs) = air_test_impl::<TestStarkEngine, BenchmarkCpuBuilder>(
+        params,
+        BenchmarkCpuBuilder,
+        config,
+        exe,
+        openvm_circuit::arch::Streams::<F>::default(),
+        1,
+        false,
+    )?;
+
+    let total_time = total_start.elapsed();
+
+    eprintln!("=== Results ===");
+    eprintln!("  Segments proved:  {}", proofs.len());
+    eprintln!("  Total time:       {:.3}s", total_time.as_secs_f64());
+
+    Ok(())
+}

--- a/benchmarks/prove/Cargo.toml
+++ b/benchmarks/prove/Cargo.toml
@@ -91,3 +91,4 @@ path = "src/bin/rkyv.rs"
 [[bin]]
 name = "revm_transfer"
 path = "src/bin/revm_transfer.rs"
+

--- a/extensions/benchmark/circuit/Cargo.toml
+++ b/extensions/benchmark/circuit/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "openvm-benchmark-circuit"
+description = "OpenVM benchmark extension for measuring proving time vs AIR complexity"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+openvm-stark-backend = { workspace = true }
+openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
+openvm-cpu-backend = { workspace = true }
+openvm-circuit-primitives = { workspace = true }
+openvm-circuit-primitives-derive = { workspace = true }
+openvm-circuit = { workspace = true }
+openvm-circuit-derive = { workspace = true }
+openvm-instructions = { workspace = true }
+
+p3-field = { workspace = true }
+
+derive-new.workspace = true
+derive_more = { workspace = true, features = ["from"] }
+serde.workspace = true
+
+[dev-dependencies]
+openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
+openvm-circuit = { workspace = true, features = ["test-utils"] }
+
+[features]
+default = ["parallel", "jemalloc"]
+tco = ["openvm-circuit/tco"]
+aot = ["openvm-circuit/aot"]
+jemalloc = ["openvm-circuit/jemalloc"]
+parallel = ["openvm-circuit/parallel"]
+test-utils = ["openvm-circuit/test-utils"]

--- a/extensions/benchmark/circuit/src/air.rs
+++ b/extensions/benchmark/circuit/src/air.rs
@@ -1,0 +1,149 @@
+use openvm_circuit::arch::{ExecutionBridge, ExecutionState, PcIncOrSet};
+use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
+use openvm_instructions::program::DEFAULT_PC_STEP;
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{Air, AirBuilder, BaseAir},
+    p3_field::PrimeCharacteristicRing,
+    p3_matrix::Matrix,
+    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+};
+
+/// Column indices for the structural columns in BenchmarkAir.
+pub const COL_IS_VALID: usize = 0;
+pub const COL_IS_FIRST: usize = 1;
+pub const COL_IS_LAST: usize = 2;
+pub const COL_SECTION_IDX: usize = 3;
+pub const COL_PC: usize = 4;
+pub const COL_TIMESTAMP: usize = 5;
+pub const NUM_STRUCTURAL_COLS: usize = 6;
+
+/// A configurable benchmark AIR with runtime-determined width.
+///
+/// Implements the DeferralOutput-style multi-row pattern:
+/// each precompile invocation spans `rows_per_invocation` consecutive rows.
+/// Only the last row of each section interacts with the execution bridge.
+///
+/// Payload columns (indices `NUM_STRUCTURAL_COLS..num_columns`) are zero-filled
+/// and constrained with boolean constraints and range check interactions.
+#[derive(Clone, Copy, Debug)]
+pub struct BenchmarkAir {
+    pub execution_bridge: ExecutionBridge,
+    pub bitwise_bus: BitwiseOperationLookupBus,
+    pub num_columns: usize,
+    pub num_constraints: usize,
+    pub num_interactions: usize,
+    pub rows_per_invocation: usize,
+    pub opcode: usize,
+}
+
+impl<F> BaseAir<F> for BenchmarkAir {
+    fn width(&self) -> usize {
+        self.num_columns
+    }
+}
+impl<F> BaseAirWithPublicValues<F> for BenchmarkAir {}
+impl<F> PartitionedBaseAir<F> for BenchmarkAir {}
+impl<F> ColumnsAir<F> for BenchmarkAir {}
+
+impl<AB> Air<AB> for BenchmarkAir
+where
+    AB: InteractionBuilder,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.row_slice(0).expect("window should have two elements");
+        let next = main.row_slice(1).expect("window should have two elements");
+
+        let local_is_valid = local[COL_IS_VALID];
+        let local_is_first = local[COL_IS_FIRST];
+        let local_section_idx = local[COL_SECTION_IDX];
+        let local_pc = local[COL_PC];
+        let local_timestamp = local[COL_TIMESTAMP];
+
+        let next_is_valid = next[COL_IS_VALID];
+        let next_is_first = next[COL_IS_FIRST];
+        let next_section_idx = next[COL_SECTION_IDX];
+        let next_pc = next[COL_PC];
+        let next_timestamp = next[COL_TIMESTAMP];
+
+        // is_transition = next row is a continuation (valid but not first)
+        let is_transition: AB::Expr = next_is_valid.into() - next_is_first.into();
+        // is_last = current row is the last of a section
+        let local_is_last: AB::Expr = local_is_valid.into() - is_transition.clone();
+
+        // -- Section structure constraints (following DeferralOutputAir) --
+
+        // is_valid and is_first are boolean
+        builder.assert_bool(local_is_valid);
+        builder.assert_bool(local_is_first);
+
+        // Valid rows are contiguous at the top of the trace
+        builder
+            .when_transition()
+            .assert_bool(AB::Expr::from(local_is_valid) - AB::Expr::from(next_is_valid));
+
+        // First valid row must be is_first
+        builder
+            .when_first_row()
+            .when(local_is_valid)
+            .assert_one(local_is_first);
+
+        // Constrain is_last column
+        builder.assert_eq(local[COL_IS_LAST], local_is_last.clone());
+
+        // Invalid rows have zero flags
+        builder
+            .when(AB::Expr::ONE - AB::Expr::from(local_is_valid))
+            .assert_zero(local_is_first);
+        builder
+            .when(AB::Expr::ONE - AB::Expr::from(local_is_valid))
+            .assert_zero(local_section_idx);
+
+        // section_idx resets on is_first, increments by 1 on transition
+        builder.when(local_is_first).assert_zero(local_section_idx);
+        builder
+            .when(is_transition.clone())
+            .assert_one(AB::Expr::from(next_section_idx) - AB::Expr::from(local_section_idx));
+
+        // State columns constant within a section (when next.section_idx != 0)
+        let mut when_section_transition = builder.when(next_section_idx);
+        when_section_transition.assert_eq(local_pc, next_pc);
+        when_section_transition.assert_eq(local_timestamp, next_timestamp);
+
+        // -- Boolean constraints on payload columns --
+        let num_payload = self.num_columns.saturating_sub(NUM_STRUCTURAL_COLS);
+        let num_bool_constraints = self.num_constraints.min(num_payload);
+        for i in 0..num_bool_constraints {
+            let col = local[NUM_STRUCTURAL_COLS + i];
+            builder
+                .when(local_is_valid)
+                .assert_zero(AB::Expr::from(col) * (AB::Expr::from(col) - AB::Expr::ONE));
+        }
+
+        // -- Range check interactions on payload columns --
+        let num_range_interactions = self.num_interactions.min(num_payload);
+        for i in 0..num_range_interactions {
+            let col = local[NUM_STRUCTURAL_COLS + i];
+            self.bitwise_bus
+                .send_range(col.into(), AB::Expr::ZERO)
+                .eval(builder, local_is_valid);
+        }
+
+        // -- Execution bridge on is_last row --
+        // Operands are all zero (our benchmark instructions have no meaningful operands)
+        // timestamp_change = 1 (minimal)
+        self.execution_bridge
+            .execute_and_increment_or_set_pc(
+                AB::Expr::from_usize(self.opcode),
+                [AB::Expr::ZERO; 5],
+                ExecutionState::<AB::Expr> {
+                    pc: local_pc.into(),
+                    timestamp: local_timestamp.into(),
+                },
+                AB::Expr::ONE,
+                PcIncOrSet::Inc(AB::Expr::from_u32(DEFAULT_PC_STEP)),
+            )
+            .eval(builder, local_is_last);
+    }
+}

--- a/extensions/benchmark/circuit/src/execution.rs
+++ b/extensions/benchmark/circuit/src/execution.rs
@@ -1,0 +1,186 @@
+use std::{
+    borrow::{Borrow, BorrowMut},
+    mem::size_of,
+    slice::from_raw_parts,
+};
+
+use openvm_circuit::arch::{
+    create_handler,
+    execution_mode::{ExecutionCtxTrait, MeteredExecutionCtxTrait},
+    E2PreCompute, InterpreterExecutor, InterpreterMeteredExecutor,
+    PreflightExecutor, RecordArena, StaticProgramError, VmExecState, VmStateMut,
+};
+use openvm_circuit_primitives::AlignedBytesBorrow;
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
+use openvm_stark_backend::p3_field::PrimeField32;
+
+#[cfg(not(feature = "tco"))]
+use openvm_circuit::arch::ExecuteFunc;
+#[cfg(feature = "tco")]
+use openvm_circuit::arch::Handler;
+#[cfg(feature = "aot")]
+use openvm_circuit::arch::{AotExecutor, AotMeteredExecutor};
+
+use crate::trace::{BenchmarkLayout, BenchmarkMetadata, BenchmarkRecordMut};
+
+use openvm_circuit::system::memory::online::{GuestMemory, TracingMemory};
+
+#[derive(Clone, Debug, derive_new::new)]
+pub struct BenchmarkExecutor {
+    pub rows_per_invocation: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, AlignedBytesBorrow)]
+struct BenchmarkPreCompute {
+    rows_per_invocation: u32,
+}
+
+impl<F: PrimeField32> InterpreterExecutor<F> for BenchmarkExecutor {
+    fn pre_compute_size(&self) -> usize {
+        size_of::<BenchmarkPreCompute>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn pre_compute<Ctx>(
+        &self,
+        _pc: u32,
+        _inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let pre_compute: &mut BenchmarkPreCompute = data.borrow_mut();
+        pre_compute.rows_per_invocation = self.rows_per_invocation as u32;
+        Ok(execute_e1_handler::<_, _>)
+    }
+
+    #[cfg(feature = "tco")]
+    fn handler<Ctx>(
+        &self,
+        _pc: u32,
+        _inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<F, Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let pre_compute: &mut BenchmarkPreCompute = data.borrow_mut();
+        pre_compute.rows_per_invocation = self.rows_per_invocation as u32;
+        Ok(execute_e1_handler::<_, _>)
+    }
+}
+
+#[cfg(feature = "aot")]
+impl<F: PrimeField32> AotExecutor<F> for BenchmarkExecutor {}
+
+impl<F: PrimeField32> InterpreterMeteredExecutor<F> for BenchmarkExecutor {
+    fn metered_pre_compute_size(&self) -> usize {
+        size_of::<E2PreCompute<BenchmarkPreCompute>>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn metered_pre_compute<Ctx>(
+        &self,
+        air_idx: usize,
+        _pc: u32,
+        _inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<F, Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let pre_compute: &mut E2PreCompute<BenchmarkPreCompute> = data.borrow_mut();
+        pre_compute.chip_idx = air_idx as u32;
+        pre_compute.data.rows_per_invocation = self.rows_per_invocation as u32;
+        Ok(execute_e2_handler::<_, _>)
+    }
+
+    #[cfg(feature = "tco")]
+    fn metered_handler<Ctx>(
+        &self,
+        air_idx: usize,
+        _pc: u32,
+        _inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<F, Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let pre_compute: &mut E2PreCompute<BenchmarkPreCompute> = data.borrow_mut();
+        pre_compute.chip_idx = air_idx as u32;
+        pre_compute.data.rows_per_invocation = self.rows_per_invocation as u32;
+        Ok(execute_e2_handler::<_, _>)
+    }
+}
+
+#[cfg(feature = "aot")]
+impl<F: PrimeField32> AotMeteredExecutor<F> for BenchmarkExecutor {}
+
+// E3: Preflight executor (record generation)
+impl<F, RA> PreflightExecutor<F, RA> for BenchmarkExecutor
+where
+    F: PrimeField32,
+    for<'buf> RA: RecordArena<'buf, BenchmarkLayout, BenchmarkRecordMut<'buf>>,
+{
+    fn get_opcode_name(&self, _opcode: usize) -> String {
+        "BENCHMARK".to_string()
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<F, TracingMemory, RA>,
+        _instruction: &Instruction<F>,
+    ) -> Result<(), openvm_circuit::arch::ExecutionError> {
+        let num_rows = self.rows_per_invocation;
+        let layout = BenchmarkLayout::new(BenchmarkMetadata { num_rows });
+        let record: BenchmarkRecordMut = state.ctx.alloc(layout);
+        record.header.from_pc = *state.pc;
+        record.header.from_timestamp = state.memory.timestamp();
+        record.header.num_rows = num_rows as u32;
+        // Advance timestamp by 1 (must match timestamp_change in the AIR)
+        state.memory.increment_timestamp();
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+// E1/E2 shared logic: just advance PC
+#[inline(always)]
+unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
+    pre_compute: &BenchmarkPreCompute,
+    exec_state: &mut VmExecState<F, GuestMemory, CTX>,
+) -> u32 {
+    let pc = exec_state.pc();
+    exec_state.set_pc(pc.wrapping_add(DEFAULT_PC_STEP));
+    pre_compute.rows_per_invocation
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_e1_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<F, GuestMemory, CTX>,
+) {
+    let pre_compute: &BenchmarkPreCompute =
+        from_raw_parts(pre_compute, size_of::<BenchmarkPreCompute>()).borrow();
+    execute_e12_impl(pre_compute, exec_state);
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_e2_impl<F: PrimeField32, CTX: MeteredExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<F, GuestMemory, CTX>,
+) {
+    let pre_compute: &E2PreCompute<BenchmarkPreCompute> = from_raw_parts(
+        pre_compute,
+        size_of::<E2PreCompute<BenchmarkPreCompute>>(),
+    )
+    .borrow();
+    let height = execute_e12_impl(&pre_compute.data, exec_state);
+    exec_state
+        .ctx
+        .on_height_change(pre_compute.chip_idx as usize, height);
+}

--- a/extensions/benchmark/circuit/src/lib.rs
+++ b/extensions/benchmark/circuit/src/lib.rs
@@ -1,0 +1,320 @@
+use std::sync::Arc;
+
+use derive_more::derive::From;
+use openvm_circuit::{
+    arch::{
+        AirInventory, AirInventoryError, ChipInventory, ChipInventoryError, ExecutionBridge,
+        ExecutorInventoryBuilder, ExecutorInventoryError, InitFileGenerator, MatrixRecordArena,
+        SystemConfig, VmBuilder, VmChipComplex, VmCircuitExtension, VmExecutionExtension, VmField,
+        VmProverExtension,
+    },
+    system::{memory::SharedMemoryHelper, SystemChipInventory, SystemCpuBuilder, SystemExecutor},
+};
+use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor, VmConfig};
+use openvm_circuit_primitives::bitwise_op_lookup::{
+    BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+    SharedBitwiseOperationLookupChip,
+};
+use openvm_cpu_backend::{CpuBackend, CpuDevice};
+use openvm_instructions::VmOpcode;
+use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
+use serde::{Deserialize, Serialize};
+
+pub mod air;
+pub mod execution;
+pub mod trace;
+
+pub use air::BenchmarkAir;
+pub use execution::BenchmarkExecutor;
+pub use trace::{
+    BenchmarkFiller, BenchmarkLayout, BenchmarkMetadata, BenchmarkRecordHeader,
+    BenchmarkRecordMut,
+};
+
+/// Base opcode offset for benchmark precompiles.
+pub const BENCHMARK_OPCODE_BASE: usize = 0x900;
+
+// ---- Extension ----
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BenchmarkExtension {
+    pub num_airs: usize,
+    pub cols_per_air: usize,
+    pub constraints_per_air: usize,
+    pub interactions_per_air: usize,
+    pub rows_per_invocation: usize,
+}
+
+#[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
+#[cfg_attr(
+    feature = "aot",
+    derive(
+        openvm_circuit_derive::AotExecutor,
+        openvm_circuit_derive::AotMeteredExecutor
+    )
+)]
+pub enum BenchmarkExecutorEnum {
+    Benchmark(BenchmarkExecutor),
+}
+
+impl<F: VmField> VmExecutionExtension<F> for BenchmarkExtension {
+    type Executor = BenchmarkExecutorEnum;
+
+    fn extend_execution(
+        &self,
+        inventory: &mut ExecutorInventoryBuilder<F, BenchmarkExecutorEnum>,
+    ) -> Result<(), ExecutorInventoryError> {
+        for i in 0..self.num_airs {
+            let executor = BenchmarkExecutor::new(self.rows_per_invocation);
+            let opcode = VmOpcode::from_usize(BENCHMARK_OPCODE_BASE + i);
+            inventory.add_executor(executor, [opcode])?;
+        }
+        Ok(())
+    }
+}
+
+impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for BenchmarkExtension
+where
+    Val<SC>: VmField,
+{
+    fn extend_circuit(&self, inventory: &mut AirInventory<SC>) -> Result<(), AirInventoryError> {
+        let execution_bridge = ExecutionBridge::new(
+            inventory.system().port().execution_bus,
+            inventory.system().port().program_bus,
+        );
+
+        // Get or create the bitwise operation lookup bus (same pattern as DeferralExtension)
+        let bitwise_bus = {
+            let existing_air = inventory.find_air::<BitwiseOperationLookupAir<8>>().next();
+            if let Some(air) = existing_air {
+                air.bus
+            } else {
+                let bus = BitwiseOperationLookupBus::new(inventory.new_bus_idx());
+                let air = BitwiseOperationLookupAir::<8>::new(bus);
+                inventory.add_air(air);
+                air.bus
+            }
+        };
+
+        for i in 0..self.num_airs {
+            inventory.add_air(BenchmarkAir {
+                execution_bridge,
+                bitwise_bus,
+                num_columns: self.cols_per_air,
+                num_constraints: self.constraints_per_air,
+                num_interactions: self.interactions_per_air,
+                rows_per_invocation: self.rows_per_invocation,
+                opcode: BENCHMARK_OPCODE_BASE + i,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+pub struct BenchmarkCpuProverExt;
+
+impl<SC, E, RA> VmProverExtension<E, RA, BenchmarkExtension> for BenchmarkCpuProverExt
+where
+    SC: StarkProtocolConfig,
+    E: StarkEngine<SC = SC, PB = CpuBackend<SC>, PD = CpuDevice<SC>>,
+    RA: openvm_circuit::arch::RowMajorMatrixArena<Val<SC>>,
+    Val<SC>: VmField,
+    SC::EF: Ord,
+{
+    fn extend_prover(
+        &self,
+        extension: &BenchmarkExtension,
+        inventory: &mut ChipInventory<SC, RA, CpuBackend<SC>>,
+    ) -> Result<(), ChipInventoryError> {
+        // Get or create the bitwise lookup chip
+        let bitwise_lu = {
+            let existing_chip = inventory
+                .find_chip::<SharedBitwiseOperationLookupChip<8>>()
+                .next();
+            if let Some(chip) = existing_chip {
+                chip.clone()
+            } else {
+                let air: &BitwiseOperationLookupAir<8> = inventory.next_air()?;
+                let chip = Arc::new(BitwiseOperationLookupChip::new(air.bus));
+                inventory.add_periphery_chip(chip.clone());
+                chip
+            }
+        };
+
+        let range_checker = inventory.range_checker()?.clone();
+        let timestamp_max_bits = inventory.timestamp_max_bits();
+        let mem_helper = SharedMemoryHelper::new(range_checker, timestamp_max_bits);
+
+        for _ in 0..extension.num_airs {
+            inventory.next_air::<BenchmarkAir>()?;
+            let filler = BenchmarkFiller::new(
+                bitwise_lu.clone(),
+                extension.cols_per_air,
+                extension.interactions_per_air,
+                extension.rows_per_invocation,
+            );
+            inventory.add_executor_chip(openvm_circuit::arch::VmChipWrapper::new(
+                filler,
+                mem_helper.clone(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+// ---- VmConfig ----
+
+#[derive(Clone, Debug, VmConfig, Serialize, Deserialize)]
+pub struct BenchmarkVmConfig {
+    #[config(executor = "SystemExecutor<F>")]
+    pub system: SystemConfig,
+    #[extension(executor = "BenchmarkExecutorEnum")]
+    pub benchmark: BenchmarkExtension,
+}
+
+impl InitFileGenerator for BenchmarkVmConfig {}
+
+// ---- VmBuilder ----
+
+#[derive(Clone)]
+pub struct BenchmarkCpuBuilder;
+
+impl<SC, E> VmBuilder<E> for BenchmarkCpuBuilder
+where
+    SC: StarkProtocolConfig,
+    E: StarkEngine<SC = SC, PB = CpuBackend<SC>, PD = CpuDevice<SC>>,
+    Val<SC>: VmField,
+    SC::EF: Ord,
+{
+    type VmConfig = BenchmarkVmConfig;
+    type SystemChipInventory = SystemChipInventory<SC>;
+    type RecordArena = MatrixRecordArena<Val<SC>>;
+
+    fn create_chip_complex(
+        &self,
+        config: &BenchmarkVmConfig,
+        circuit: AirInventory<SC>,
+    ) -> Result<
+        VmChipComplex<SC, Self::RecordArena, E::PB, Self::SystemChipInventory>,
+        ChipInventoryError,
+    > {
+        let mut chip_complex =
+            VmBuilder::<E>::create_chip_complex(&SystemCpuBuilder, &config.system, circuit)?;
+        VmProverExtension::<E, _, _>::extend_prover(
+            &BenchmarkCpuProverExt,
+            &config.benchmark,
+            &mut chip_complex.inventory,
+        )?;
+        Ok(chip_complex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_circuit::{
+        arch::{instructions::exe::VmExe, SystemConfig},
+        utils::air_test,
+    };
+    use openvm_instructions::{
+        instruction::Instruction, program::Program, LocalOpcode, SystemOpcode::TERMINATE,
+    };
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    type F = BabyBear;
+
+    #[test]
+    fn test_benchmark_air_small() {
+        let num_airs = 1;
+        let cols_per_air = 16;
+        let rows_per_invocation = 4;
+        let invocations = 4;
+
+        let ext = BenchmarkExtension {
+            num_airs,
+            cols_per_air,
+            constraints_per_air: 4,
+            interactions_per_air: 2,
+            rows_per_invocation,
+        };
+        let config = BenchmarkVmConfig {
+            system: SystemConfig::default().with_max_segment_len(1 << 20),
+            benchmark: ext,
+        };
+
+        let mut instructions: Vec<Instruction<F>> = Vec::new();
+        for _ in 0..invocations {
+            for air_idx in 0..num_airs {
+                instructions.push(Instruction::from_isize(
+                    VmOpcode::from_usize(BENCHMARK_OPCODE_BASE + air_idx),
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ));
+            }
+        }
+        instructions.push(Instruction::from_isize(
+            TERMINATE.global_opcode(),
+            0,
+            0,
+            0,
+            0,
+            0,
+        ));
+
+        let program = Program::from_instructions(&instructions);
+        let exe = VmExe::new(program);
+        air_test(BenchmarkCpuBuilder, config, exe);
+    }
+
+    #[test]
+    fn test_benchmark_air_multi_air() {
+        let num_airs = 3;
+        let cols_per_air = 16;
+        let rows_per_invocation = 2;
+        let invocations_per_air = 4;
+
+        let ext = BenchmarkExtension {
+            num_airs,
+            cols_per_air,
+            constraints_per_air: 2,
+            interactions_per_air: 1,
+            rows_per_invocation,
+        };
+        let config = BenchmarkVmConfig {
+            system: SystemConfig::default().with_max_segment_len(1 << 20),
+            benchmark: ext,
+        };
+
+        let mut instructions: Vec<Instruction<F>> = Vec::new();
+        for _ in 0..invocations_per_air {
+            for air_idx in 0..num_airs {
+                instructions.push(Instruction::from_isize(
+                    VmOpcode::from_usize(BENCHMARK_OPCODE_BASE + air_idx),
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ));
+            }
+        }
+        instructions.push(Instruction::from_isize(
+            TERMINATE.global_opcode(),
+            0,
+            0,
+            0,
+            0,
+            0,
+        ));
+
+        let program = Program::from_instructions(&instructions);
+        let exe = VmExe::new(program);
+        air_test(BenchmarkCpuBuilder, config, exe);
+    }
+}

--- a/extensions/benchmark/circuit/src/trace.rs
+++ b/extensions/benchmark/circuit/src/trace.rs
@@ -1,0 +1,133 @@
+use std::{
+    borrow::{Borrow, BorrowMut},
+    mem::{align_of, size_of},
+};
+
+use openvm_circuit::arch::{
+    get_record_from_slice, CustomBorrow, MultiRowLayout, MultiRowMetadata, SizedRecord, TraceFiller,
+    VmField,
+};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::SharedBitwiseOperationLookupChip, AlignedBytesBorrow,
+};
+use openvm_stark_backend::p3_matrix::dense::RowMajorMatrix;
+
+use crate::air::{COL_IS_FIRST, COL_IS_LAST, COL_IS_VALID, COL_PC, COL_SECTION_IDX, COL_TIMESTAMP};
+
+// ---- Record types ----
+
+/// Metadata type that does NOT implement Default, to avoid blanket CustomBorrow conflicts.
+#[derive(Clone, Copy, Debug)]
+pub struct BenchmarkMetadata {
+    pub num_rows: usize,
+}
+
+impl MultiRowMetadata for BenchmarkMetadata {
+    #[inline(always)]
+    fn get_num_rows(&self) -> usize {
+        self.num_rows
+    }
+}
+
+pub type BenchmarkLayout = MultiRowLayout<BenchmarkMetadata>;
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug, Clone)]
+pub struct BenchmarkRecordHeader {
+    pub from_pc: u32,
+    pub from_timestamp: u32,
+    pub num_rows: u32,
+}
+
+/// Custom record wrapper (avoids blanket impl conflicts on `&mut T`).
+pub struct BenchmarkRecordMut<'a> {
+    pub header: &'a mut BenchmarkRecordHeader,
+}
+
+impl<'a> CustomBorrow<'a, BenchmarkRecordMut<'a>, BenchmarkLayout> for [u8] {
+    fn custom_borrow(&'a mut self, _layout: BenchmarkLayout) -> BenchmarkRecordMut<'a> {
+        let (header_buf, _rest) =
+            unsafe { self.split_at_mut_unchecked(size_of::<BenchmarkRecordHeader>()) };
+        BenchmarkRecordMut {
+            header: header_buf.borrow_mut(),
+        }
+    }
+
+    unsafe fn extract_layout(&self) -> BenchmarkLayout {
+        let record: &BenchmarkRecordHeader =
+            self[..size_of::<BenchmarkRecordHeader>()].borrow();
+        BenchmarkLayout {
+            metadata: BenchmarkMetadata {
+                num_rows: record.num_rows as usize,
+            },
+        }
+    }
+}
+
+impl SizedRecord<BenchmarkLayout> for BenchmarkRecordMut<'_> {
+    fn size(_layout: &BenchmarkLayout) -> usize {
+        size_of::<BenchmarkRecordHeader>()
+    }
+
+    fn alignment(_layout: &BenchmarkLayout) -> usize {
+        align_of::<BenchmarkRecordHeader>()
+    }
+}
+
+// ---- Filler ----
+
+#[derive(Clone, derive_new::new)]
+pub struct BenchmarkFiller {
+    pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<8>,
+    pub num_columns: usize,
+    pub num_interactions: usize,
+    pub rows_per_invocation: usize,
+}
+
+impl<F> TraceFiller<F> for BenchmarkFiller
+where
+    F: VmField,
+{
+    fn fill_trace(
+        &self,
+        _mem_helper: &openvm_circuit::system::memory::MemoryAuxColsFactory<F>,
+        trace_matrix: &mut RowMajorMatrix<F>,
+        rows_used: usize,
+    ) {
+        if rows_used == 0 {
+            return;
+        }
+
+        let width = trace_matrix.width;
+        let mut trace = &mut trace_matrix.values[..width * rows_used];
+
+        while !trace.is_empty() {
+            // Peek at the record header (uses blanket CustomBorrow<&mut T, ()>)
+            let header: &BenchmarkRecordHeader =
+                unsafe { get_record_from_slice(&mut trace, ()) };
+            let num_rows = header.num_rows as usize;
+            let from_pc = header.from_pc;
+            let from_timestamp = header.from_timestamp;
+
+            // Split off this section's rows
+            let (section, rest) = trace.split_at_mut(width * num_rows);
+            trace = rest;
+
+            // Fill each row of the section
+            for (row_idx, row) in section.chunks_exact_mut(width).enumerate() {
+                row[COL_IS_VALID] = F::ONE;
+                row[COL_IS_FIRST] = F::from_bool(row_idx == 0);
+                row[COL_IS_LAST] = F::from_bool(row_idx + 1 == num_rows);
+                row[COL_SECTION_IDX] = F::from_usize(row_idx);
+                row[COL_PC] = F::from_u32(from_pc);
+                row[COL_TIMESTAMP] = F::from_u32(from_timestamp);
+                // All payload columns remain zero (default-initialized)
+
+                // Track bitwise lookup multiplicities for range check interactions
+                for _ in 0..self.num_interactions {
+                    self.bitwise_lookup_chip.request_range(0, 0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Add configurable benchmark extension (`extensions/benchmark/circuit/`) with no-op precompiles that accept zero witnesses
  - Add standalone binary (`benchmarks/air-complexity/`) to measure proving time as a function of: number of AIRs, columns per AIR,
  constraints per AIR, and bus interactions per AIR
  - Multi-row invocations ensure precompile traces dominate system overhead; VmExe constructed directly from flat instruction sequence
  (no RV32I needed)

  ## Test plan
  - [x] `cargo test -p openvm-benchmark-circuit` passes (2 tests: single AIR + multi AIR)
  - [x] `cargo run -p openvm-benchmark-air-complexity -- --num-airs 2 --cols-per-air 16 --total-cells 4096 --rows-per-invocation 4`
  completes successfully

  🤖 Generated with [Claude Code](https://claude.com/claude-code)