### PR TITLE
Move ColumnsAir trait from stark-backend fork into OpenVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9884,7 +9884,8 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "struct-reflection"
 version = "0.1.0"
-source = "git+https://github.com/gzanitti/struct-reflection-rs.git#b763b1be4e83d07669f263650517ef889ee8327d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701b671d1ad68e250e05718f95dae3014a17f4e69cbe51842531c30495ff3301"
 dependencies = [
  "struct-reflection-derive",
 ]
@@ -9892,7 +9893,8 @@ dependencies = [
 [[package]]
 name = "struct-reflection-derive"
 version = "0.1.0"
-source = "git+https://github.com/gzanitti/struct-reflection-rs.git#b763b1be4e83d07669f263650517ef889ee8327d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ab74230a0592602e361bd63c645413fa8cbe4500d10274e849179e5c72548f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -674,7 +674,7 @@ checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.2",
  "serde_json",
  "tower",
@@ -3249,7 +3249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ dependencies = [
  "dyn-clone",
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "path-slash",
  "rayon",
  "semver 1.0.27",
@@ -4660,7 +4660,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6033,6 +6033,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6079,6 +6080,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -6103,6 +6105,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6129,6 +6132,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "cc",
  "glob",
@@ -6137,6 +6141,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6600,6 +6605,7 @@ version = "2.0.0-beta.2"
 dependencies = [
  "derivative",
  "lazy_static",
+ "openvm-circuit-primitives",
  "openvm-cuda-backend",
  "openvm-cuda-builder",
  "openvm-cuda-common",
@@ -6927,6 +6933,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -6961,6 +6968,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
+source = "git+https://github.com/powdr-labs/stark-backend.git?branch=v2-powdr-beta.2-remove-columns-air#1d719aa9d5f3d2b18a2692bfbb55d009db7a3e4e"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -8939,7 +8947,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8997,7 +9005,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9691,7 +9699,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -9727,7 +9735,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "memchr",
  "num-bigint 0.4.6",
  "num-rational",
@@ -10159,7 +10167,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11248,7 +11256,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,13 +116,13 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-codec-derive = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cpu-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-codec-derive = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cpu-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
 
 # OpenVM
 openvm-mod-circuit-builder = { path = "crates/circuits/mod-builder", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ snark-verifier-sdk = { version = "0.2.0", default-features = false, features = [
 snark-verifier = { version = "0.2.0", default-features = false }
 halo2-base = { version = "0.5.0", default-features = false }
 halo2curves-axiom = { git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
-struct-reflection = { git = "https://github.com/gzanitti/struct-reflection-rs.git" }
+struct-reflection = "0.1.0"
 
 forge-fmt = { git = "https://github.com/foundry-rs/foundry.git", tag = "v1.5.0" }
 cargo_metadata = "0.18"

--- a/crates/circuits/mod-builder/src/builder.rs
+++ b/crates/circuits/mod-builder/src/builder.rs
@@ -11,14 +11,14 @@ use openvm_circuit_primitives::{
         OverflowInt,
     },
     var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
-    SubAir, TraceSubRowGenerator,
+    ColumnsAir, SubAir, TraceSubRowGenerator,
 };
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField64},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::{FieldVariable, SymbolicExpr};

--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -13,14 +13,14 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerChip},
-    SubAir, TraceSubRowGenerator,
+    ColumnsAir, SubAir, TraceSubRowGenerator,
 };
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 

--- a/crates/circuits/poseidon2-air/Cargo.toml
+++ b/crates/circuits/poseidon2-air/Cargo.toml
@@ -16,6 +16,7 @@ zkhash = { workspace = true }
 
 openvm-stark-backend = { workspace = true }
 openvm-stark-sdk = { workspace = true, features = ["cpu-backend"] }
+openvm-circuit-primitives = { workspace = true, default-features = false }
 openvm-cuda-backend = { workspace = true, optional = true }
 openvm-cuda-common = { workspace = true, optional = true }
 
@@ -32,6 +33,6 @@ openvm-cuda-builder.workspace = true
 
 [features]
 default = ["parallel"]
-parallel = ["openvm-stark-backend/parallel", "openvm-stark-sdk/parallel"]
+parallel = ["openvm-stark-backend/parallel", "openvm-stark-sdk/parallel", "openvm-circuit-primitives/parallel"]
 cuda = ["dep:openvm-cuda-common", "dep:openvm-cuda-backend"]
 touchemall = ["openvm-cuda-backend/touchemall"]

--- a/crates/circuits/poseidon2-air/Cargo.toml
+++ b/crates/circuits/poseidon2-air/Cargo.toml
@@ -33,6 +33,6 @@ openvm-cuda-builder.workspace = true
 
 [features]
 default = ["parallel"]
-parallel = ["openvm-stark-backend/parallel", "openvm-stark-sdk/parallel", "openvm-circuit-primitives/parallel"]
+parallel = ["openvm-stark-backend/parallel", "openvm-stark-sdk/parallel"]
 cuda = ["dep:openvm-cuda-common", "dep:openvm-cuda-backend"]
 touchemall = ["openvm-cuda-backend/touchemall"]

--- a/crates/circuits/poseidon2-air/src/air.rs
+++ b/crates/circuits/poseidon2-air/src/air.rs
@@ -1,7 +1,8 @@
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_poseidon2_air::{Poseidon2Air, Poseidon2Cols};
 

--- a/crates/circuits/primitives/src/assert_less_than/tests.rs
+++ b/crates/circuits/primitives/src/assert_less_than/tests.rs
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 #[cfg(not(feature = "cuda"))]
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
@@ -33,7 +33,7 @@ use super::*;
 use crate::{
     utils::test_engine_small,
     var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
-    StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper,
 };
 
 // We only create an Air for testing purposes

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;
@@ -56,7 +56,11 @@ impl<F: Field, const NUM_BITS: usize> PartitionedBaseAir<F>
     for BitwiseOperationLookupAir<NUM_BITS>
 {
 }
-crate::impl_columns_air!([const NUM_BITS: usize] BitwiseOperationLookupAir<NUM_BITS>, BitwiseOperationLookupCols<F, NUM_BITS>);
+impl<F: Field, const NUM_BITS: usize> ColumnsAir<F> for BitwiseOperationLookupAir<NUM_BITS> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <BitwiseOperationLookupCols<F, NUM_BITS> as crate::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field, const NUM_BITS: usize> BaseAir<F> for BitwiseOperationLookupAir<NUM_BITS> {
     fn width(&self) -> usize {
         BitwiseOperationLookupCols::<F, NUM_BITS>::width()

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -11,10 +11,10 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;

--- a/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/mod.rs
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
-use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
+use crate::{Chip, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;
@@ -56,11 +56,7 @@ impl<F: Field, const NUM_BITS: usize> PartitionedBaseAir<F>
     for BitwiseOperationLookupAir<NUM_BITS>
 {
 }
-impl<F: Field, const NUM_BITS: usize> ColumnsAir<F> for BitwiseOperationLookupAir<NUM_BITS> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <BitwiseOperationLookupCols<F, NUM_BITS> as crate::StructReflectionHelper>::struct_reflection()
-    }
-}
+crate::impl_columns_air!([const NUM_BITS: usize] BitwiseOperationLookupAir<NUM_BITS>, BitwiseOperationLookupCols<F, NUM_BITS>);
 impl<F: Field, const NUM_BITS: usize> BaseAir<F> for BitwiseOperationLookupAir<NUM_BITS> {
     fn width(&self) -> usize {
         BitwiseOperationLookupCols::<F, NUM_BITS>::width()

--- a/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
+++ b/crates/circuits/primitives/src/bitwise_op_lookup/tests/dummy.rs
@@ -3,10 +3,10 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
-use crate::bitwise_op_lookup::bus::BitwiseOperationLookupBus;
+use crate::{bitwise_op_lookup::bus::BitwiseOperationLookupBus, ColumnsAir};
 
 pub struct DummyAir {
     bus: BitwiseOperationLookupBus,
@@ -51,7 +51,7 @@ pub mod cuda {
 
     use crate::{
         bitwise_op_lookup::BitwiseOperationLookupChipGPU,
-        cuda_abi::bitwise_op_lookup::dummy_tracegen, Chip,
+        cuda_abi::bitwise_op_lookup::dummy_tracegen, Chip, ColumnsAir,
     };
 
     const RECORD_WIDTH: usize = 3;

--- a/crates/circuits/primitives/src/columns_air.rs
+++ b/crates/circuits/primitives/src/columns_air.rs
@@ -1,0 +1,10 @@
+use openvm_stark_backend::p3_air::BaseAir;
+
+/// If available, returns the names of columns used in this AIR.
+pub trait ColumnsAir<F>: BaseAir<F> {
+    /// If the result is `Some(names)`, `names.len() == air.width()` should always
+    /// be true.
+    fn columns(&self) -> Option<Vec<String>> {
+        None
+    }
+}

--- a/crates/circuits/primitives/src/columns_air.rs
+++ b/crates/circuits/primitives/src/columns_air.rs
@@ -8,34 +8,3 @@ pub trait ColumnsAir<F>: BaseAir<F> {
         None
     }
 }
-
-/// Implements [`ColumnsAir<F>`] by deferring to a [`StructReflection`](crate::StructReflection)
-/// derive on the columns struct. Two forms:
-///
-/// ```ignore
-/// // No extra generics on the AIR:
-/// impl_columns_air!(MyAir, MyCols<F>);
-///
-/// // With const generics on the AIR (Cols generics may differ); brackets avoid
-/// // ambiguity with Rust 2024 const-trait-impl syntax:
-/// impl_columns_air!([const N: usize, const M: usize] MyAir<N, M>, MyCols<F, N>);
-/// ```
-#[macro_export]
-macro_rules! impl_columns_air {
-    // The bracketed-generics arm must come first; otherwise the simpler arm's `$air:ty` would
-    // try to parse `[const M: usize]` as an array type.
-    ([$($gp:tt)*] $air:ty, $cols:ty) => {
-        impl<F: openvm_stark_backend::p3_field::Field, $($gp)*> $crate::ColumnsAir<F> for $air {
-            fn columns(&self) -> Option<Vec<String>> {
-                <$cols as $crate::StructReflectionHelper>::struct_reflection()
-            }
-        }
-    };
-    ($air:ty, $cols:ty) => {
-        impl<F: openvm_stark_backend::p3_field::Field> $crate::ColumnsAir<F> for $air {
-            fn columns(&self) -> Option<Vec<String>> {
-                <$cols as $crate::StructReflectionHelper>::struct_reflection()
-            }
-        }
-    };
-}

--- a/crates/circuits/primitives/src/columns_air.rs
+++ b/crates/circuits/primitives/src/columns_air.rs
@@ -8,3 +8,34 @@ pub trait ColumnsAir<F>: BaseAir<F> {
         None
     }
 }
+
+/// Implements [`ColumnsAir<F>`] by deferring to a [`StructReflection`](crate::StructReflection)
+/// derive on the columns struct. Two forms:
+///
+/// ```ignore
+/// // No extra generics on the AIR:
+/// impl_columns_air!(MyAir, MyCols<F>);
+///
+/// // With const generics on the AIR (Cols generics may differ); brackets avoid
+/// // ambiguity with Rust 2024 const-trait-impl syntax:
+/// impl_columns_air!([const N: usize, const M: usize] MyAir<N, M>, MyCols<F, N>);
+/// ```
+#[macro_export]
+macro_rules! impl_columns_air {
+    // The bracketed-generics arm must come first; otherwise the simpler arm's `$air:ty` would
+    // try to parse `[const M: usize]` as an array type.
+    ([$($gp:tt)*] $air:ty, $cols:ty) => {
+        impl<F: openvm_stark_backend::p3_field::Field, $($gp)*> $crate::ColumnsAir<F> for $air {
+            fn columns(&self) -> Option<Vec<String>> {
+                <$cols as $crate::StructReflectionHelper>::struct_reflection()
+            }
+        }
+    };
+    ($air:ty, $cols:ty) => {
+        impl<F: openvm_stark_backend::p3_field::Field> $crate::ColumnsAir<F> for $air {
+            fn columns(&self) -> Option<Vec<String>> {
+                <$cols as $crate::StructReflectionHelper>::struct_reflection()
+            }
+        }
+    };
+}

--- a/crates/circuits/primitives/src/is_equal/tests.rs
+++ b/crates/circuits/primitives/src/is_equal/tests.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 use test_case::test_matrix;
 #[cfg(feature = "cuda")]
@@ -27,7 +27,7 @@ use {
 
 use super::{IsEqSubAir, IsEqualIo};
 use crate::{
-    utils::test_engine_small, StructReflection, StructReflectionHelper, SubAir,
+    utils::test_engine_small, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
     TraceSubRowGenerator,
 };
 

--- a/crates/circuits/primitives/src/is_equal_array/tests.rs
+++ b/crates/circuits/primitives/src/is_equal_array/tests.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 #[cfg(not(feature = "cuda"))]
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
@@ -32,7 +32,7 @@ use {
 
 use super::{IsEqArrayAuxCols, IsEqArrayIo, IsEqArraySubAir};
 use crate::{
-    utils::test_engine_small, StructReflection, StructReflectionHelper, SubAir,
+    utils::test_engine_small, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
     TraceSubRowGenerator,
 };
 

--- a/crates/circuits/primitives/src/is_less_than/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than/tests.rs
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 #[cfg(feature = "cuda")]
 use {
@@ -26,7 +26,7 @@ use crate::{
     is_less_than::IsLtSubAir,
     utils::test_engine_small,
     var_range::{VariableRangeCheckerBus, VariableRangeCheckerChip},
-    SubAir, TraceSubRowGenerator,
+    ColumnsAir, SubAir, TraceSubRowGenerator,
 };
 
 /// Struct purely for testing purposes. We could make this have a const generic just like

--- a/crates/circuits/primitives/src/is_less_than_array/tests.rs
+++ b/crates/circuits/primitives/src/is_less_than_array/tests.rs
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 #[cfg(feature = "cuda")]
 use {
@@ -24,7 +24,7 @@ use {
 };
 
 use super::*;
-use crate::{utils::test_engine_small, StructReflection, StructReflectionHelper};
+use crate::{utils::test_engine_small, ColumnsAir, StructReflection, StructReflectionHelper};
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Clone, Copy, Debug)]

--- a/crates/circuits/primitives/src/is_zero/tests.rs
+++ b/crates/circuits/primitives/src/is_zero/tests.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
     utils::disable_debug_builder,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkTestError,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkTestError,
 };
 #[cfg(not(feature = "cuda"))]
 use openvm_stark_sdk::config::baby_bear_poseidon2::F;
@@ -29,7 +29,7 @@ use {
 
 use super::{IsZeroIo, IsZeroSubAir};
 use crate::{
-    utils::test_engine_small, StructReflection, StructReflectionHelper, SubAir,
+    utils::test_engine_small, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
     TraceSubRowGenerator,
 };
 

--- a/crates/circuits/primitives/src/lib.rs
+++ b/crates/circuits/primitives/src/lib.rs
@@ -25,6 +25,9 @@ pub use openvm_circuit_primitives_derive::*;
 /// Struct reflection for column names
 pub use struct_reflection::{StructReflection, StructReflectionHelper};
 
+mod columns_air;
+pub use columns_air::ColumnsAir;
+
 pub mod assert_less_than;
 pub mod bigint;
 pub mod bitwise_op_lookup;

--- a/crates/circuits/primitives/src/range/mod.rs
+++ b/crates/circuits/primitives/src/range/mod.rs
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
-use crate::{StructReflection, StructReflectionHelper};
+use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 
@@ -58,7 +58,11 @@ impl RangeCheckerAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerAir {}
 impl<F: Field> PartitionedBaseAir<F> for RangeCheckerAir {}
-crate::impl_columns_air!(RangeCheckerAir, RangeCols<F>);
+impl<F: Field> ColumnsAir<F> for RangeCheckerAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <RangeCols<F> as crate::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAir<F> for RangeCheckerAir {
     fn width(&self) -> usize {
         NUM_RANGE_COLS

--- a/crates/circuits/primitives/src/range/mod.rs
+++ b/crates/circuits/primitives/src/range/mod.rs
@@ -16,10 +16,10 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir, PairBuilder},
     p3_field::Field,
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
-use crate::{StructReflection, StructReflectionHelper};
+use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 

--- a/crates/circuits/primitives/src/range/mod.rs
+++ b/crates/circuits/primitives/src/range/mod.rs
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
-use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
+use crate::{StructReflection, StructReflectionHelper};
 
 mod bus;
 
@@ -58,11 +58,7 @@ impl RangeCheckerAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerAir {}
 impl<F: Field> PartitionedBaseAir<F> for RangeCheckerAir {}
-impl<F: Field> ColumnsAir<F> for RangeCheckerAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <RangeCols<F> as crate::StructReflectionHelper>::struct_reflection()
-    }
-}
+crate::impl_columns_air!(RangeCheckerAir, RangeCols<F>);
 impl<F: Field> BaseAir<F> for RangeCheckerAir {
     fn width(&self) -> usize {
         NUM_RANGE_COLS

--- a/crates/circuits/primitives/src/range/tests/list/air.rs
+++ b/crates/circuits/primitives/src/range/tests/list/air.rs
@@ -5,11 +5,11 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::columns::{ListCols, NUM_LIST_COLS};
-use crate::range::bus::RangeCheckBus;
+use crate::{range::bus::RangeCheckBus, ColumnsAir};
 
 #[derive(Copy, Clone, Debug, derive_new::new)]
 pub struct ListAir {

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -16,11 +16,11 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_util::indices_arr,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 pub use crate::range::RangeCheckBus;
-use crate::{StructReflection, StructReflectionHelper};
+use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -20,7 +20,7 @@ use openvm_stark_backend::{
 };
 
 pub use crate::range::RangeCheckBus;
-use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
+use crate::{StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;
@@ -53,11 +53,7 @@ pub struct RangeCheckerGateAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerGateAir {}
 impl<F: Field> PartitionedBaseAir<F> for RangeCheckerGateAir {}
-impl<F: Field> ColumnsAir<F> for RangeCheckerGateAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <RangeGateCols<F> as crate::StructReflectionHelper>::struct_reflection()
-    }
-}
+crate::impl_columns_air!(RangeCheckerGateAir, RangeGateCols<F>);
 impl<F: Field> BaseAir<F> for RangeCheckerGateAir {
     fn width(&self) -> usize {
         NUM_RANGE_GATE_COLS

--- a/crates/circuits/primitives/src/range_gate/mod.rs
+++ b/crates/circuits/primitives/src/range_gate/mod.rs
@@ -20,7 +20,7 @@ use openvm_stark_backend::{
 };
 
 pub use crate::range::RangeCheckBus;
-use crate::{StructReflection, StructReflectionHelper};
+use crate::{ColumnsAir, StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;
@@ -53,7 +53,11 @@ pub struct RangeCheckerGateAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for RangeCheckerGateAir {}
 impl<F: Field> PartitionedBaseAir<F> for RangeCheckerGateAir {}
-crate::impl_columns_air!(RangeCheckerGateAir, RangeGateCols<F>);
+impl<F: Field> ColumnsAir<F> for RangeCheckerGateAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <RangeGateCols<F> as crate::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAir<F> for RangeCheckerGateAir {
     fn width(&self) -> usize {
         NUM_RANGE_GATE_COLS

--- a/crates/circuits/primitives/src/range_tuple/mod.rs
+++ b/crates/circuits/primitives/src/range_tuple/mod.rs
@@ -16,10 +16,10 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
-use crate::Chip;
+use crate::{Chip, ColumnsAir};
 
 mod bus;
 pub use bus::*;

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -17,11 +17,11 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 use tracing::instrument;
 
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -21,7 +21,7 @@ use openvm_stark_backend::{
 };
 use tracing::instrument;
 
-use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
+use crate::{Chip, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;
@@ -62,11 +62,7 @@ impl VariableRangeCheckerAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for VariableRangeCheckerAir {}
 impl<F: Field> PartitionedBaseAir<F> for VariableRangeCheckerAir {}
-impl<F: Field> ColumnsAir<F> for VariableRangeCheckerAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <VariableRangeCols<F> as crate::StructReflectionHelper>::struct_reflection()
-    }
-}
+crate::impl_columns_air!(VariableRangeCheckerAir, VariableRangeCols<F>);
 impl<F: Field> BaseAir<F> for VariableRangeCheckerAir {
     fn width(&self) -> usize {
         VariableRangeCols::<F>::width()

--- a/crates/circuits/primitives/src/var_range/mod.rs
+++ b/crates/circuits/primitives/src/var_range/mod.rs
@@ -21,7 +21,7 @@ use openvm_stark_backend::{
 };
 use tracing::instrument;
 
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 mod bus;
 pub use bus::*;
@@ -62,7 +62,11 @@ impl VariableRangeCheckerAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for VariableRangeCheckerAir {}
 impl<F: Field> PartitionedBaseAir<F> for VariableRangeCheckerAir {}
-crate::impl_columns_air!(VariableRangeCheckerAir, VariableRangeCols<F>);
+impl<F: Field> ColumnsAir<F> for VariableRangeCheckerAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <VariableRangeCols<F> as crate::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAir<F> for VariableRangeCheckerAir {
     fn width(&self) -> usize {
         VariableRangeCols::<F>::width()

--- a/crates/circuits/primitives/src/var_range/tests/dummy.rs
+++ b/crates/circuits/primitives/src/var_range/tests/dummy.rs
@@ -3,10 +3,10 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
-use crate::var_range::bus::VariableRangeCheckerBus;
+use crate::{var_range::bus::VariableRangeCheckerBus, ColumnsAir};
 
 // dummy AIR for testing VariableRangeCheckerBus::send
 pub struct TestSendAir {
@@ -87,6 +87,7 @@ pub mod cuda {
 
     use crate::{
         cuda_abi::var_range::dummy_tracegen, var_range::VariableRangeCheckerChipGPU, Chip,
+        ColumnsAir,
     };
 
     /// Width of the dummy trace: [count, value, bits] = 3 columns

--- a/crates/circuits/primitives/src/xor/lookup/mod.rs
+++ b/crates/circuits/primitives/src/xor/lookup/mod.rs
@@ -21,7 +21,7 @@ use openvm_stark_backend::{
 };
 
 use super::bus::XorBus;
-use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
+use crate::{Chip, StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;
@@ -56,11 +56,7 @@ pub struct XorLookupAir<const M: usize> {
 
 impl<F: Field, const M: usize> BaseAirWithPublicValues<F> for XorLookupAir<M> {}
 impl<F: Field, const M: usize> PartitionedBaseAir<F> for XorLookupAir<M> {}
-impl<F: Field, const M: usize> ColumnsAir<F> for XorLookupAir<M> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <XorLookupCols<F> as crate::StructReflectionHelper>::struct_reflection()
-    }
-}
+crate::impl_columns_air!([const M: usize] XorLookupAir<M>, XorLookupCols<F>);
 impl<F: Field, const M: usize> BaseAir<F> for XorLookupAir<M> {
     fn width(&self) -> usize {
         NUM_XOR_LOOKUP_COLS

--- a/crates/circuits/primitives/src/xor/lookup/mod.rs
+++ b/crates/circuits/primitives/src/xor/lookup/mod.rs
@@ -17,11 +17,11 @@ use openvm_stark_backend::{
     p3_field::Field,
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
 use super::bus::XorBus;
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;

--- a/crates/circuits/primitives/src/xor/lookup/mod.rs
+++ b/crates/circuits/primitives/src/xor/lookup/mod.rs
@@ -21,7 +21,7 @@ use openvm_stark_backend::{
 };
 
 use super::bus::XorBus;
-use crate::{Chip, StructReflection, StructReflectionHelper};
+use crate::{Chip, ColumnsAir, StructReflection, StructReflectionHelper};
 
 #[cfg(test)]
 mod tests;
@@ -56,7 +56,11 @@ pub struct XorLookupAir<const M: usize> {
 
 impl<F: Field, const M: usize> BaseAirWithPublicValues<F> for XorLookupAir<M> {}
 impl<F: Field, const M: usize> PartitionedBaseAir<F> for XorLookupAir<M> {}
-crate::impl_columns_air!([const M: usize] XorLookupAir<M>, XorLookupCols<F>);
+impl<F: Field, const M: usize> ColumnsAir<F> for XorLookupAir<M> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <XorLookupCols<F> as crate::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field, const M: usize> BaseAir<F> for XorLookupAir<M> {
     fn width(&self) -> usize {
         NUM_XOR_LOOKUP_COLS

--- a/crates/circuits/sha2-air/src/air.rs
+++ b/crates/circuits/sha2-air/src/air.rs
@@ -2,14 +2,14 @@ use std::{iter::once, marker::PhantomData};
 
 use ndarray::s;
 use openvm_circuit_primitives::{
-    bitwise_op_lookup::BitwiseOperationLookupBus, encoder::Encoder, utils::select, SubAir,
+    bitwise_op_lookup::BitwiseOperationLookupBus, encoder::Encoder, utils::select, ColumnsAir,
+    SubAir,
 };
 use openvm_stark_backend::{
     interaction::{BusIndex, InteractionBuilder, PermutationCheckBus},
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::Matrix,
-    ColumnsAir,
 };
 
 use super::{

--- a/crates/continuations/src/circuit/deferral/hook/decommit/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/decommit/air.rs
@@ -1,10 +1,10 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::not, SubAir};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, SubAir};
 use openvm_recursion_circuit::utils::assert_zeros;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/continuations/src/circuit/deferral/hook/onion/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/onion/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::utils::not;
+use openvm_circuit_primitives::{utils::not, ColumnsAir};
 use openvm_recursion_circuit::{
     bus::{Poseidon2CompressBus, Poseidon2CompressMessage},
     prelude::DIGEST_SIZE,
@@ -8,7 +8,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_matrix::Matrix;

--- a/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/hook/verifier/air.rs
@@ -1,14 +1,14 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use openvm_circuit::arch::POSEIDON2_WIDTH;
-use openvm_circuit_primitives::SubAir;
+use openvm_circuit_primitives::{ColumnsAir, SubAir};
 use openvm_recursion_circuit::bus::{
     CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
     PreHashBus, PreHashMessage, PublicValuesBus, PublicValuesBusMessage,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{

--- a/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/def_pvs/air.rs
@@ -1,6 +1,9 @@
 use std::{array::from_fn, borrow::Borrow};
 
-use openvm_circuit_primitives::utils::{assert_array_eq, not};
+use openvm_circuit_primitives::{
+    utils::{assert_array_eq, not},
+    ColumnsAir,
+};
 use openvm_recursion_circuit::{
     bus::{
         Poseidon2CompressBus, Poseidon2CompressMessage, PublicValuesBus, PublicValuesBusMessage,
@@ -9,7 +12,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/continuations/src/circuit/deferral/inner/input/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/input/air.rs
@@ -1,6 +1,6 @@
 use std::{array::from_fn, borrow::Borrow};
 
-use openvm_circuit_primitives::{utils::not, SubAir};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, SubAir};
 use openvm_recursion_circuit::{
     bus::{
         CachedCommitBus, CachedCommitBusMessage, Poseidon2PermuteBus, Poseidon2PermuteMessage,
@@ -11,7 +11,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/deferral/inner/verifier/air.rs
@@ -1,13 +1,16 @@
 use std::{array::from_fn, borrow::Borrow};
 
-use openvm_circuit_primitives::utils::{and, not};
+use openvm_circuit_primitives::{
+    utils::{and, not},
+    ColumnsAir,
+};
 use openvm_recursion_circuit::bus::{
     CachedCommitBus, CachedCommitBusMessage, PreHashBus, PreHashMessage, PublicValuesBus,
     PublicValuesBusMessage,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_verify_stark_host::pvs::{
     VerifierBasePvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, VERIFIER_PVS_AIR_ID,

--- a/crates/continuations/src/circuit/inner/def_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/def_pvs/air.rs
@@ -1,13 +1,16 @@
 use std::{array::from_fn, borrow::Borrow};
 
-use openvm_circuit_primitives::utils::{assert_array_eq, not};
+use openvm_circuit_primitives::{
+    utils::{assert_array_eq, not},
+    ColumnsAir,
+};
 use openvm_recursion_circuit::bus::{
     CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
     PublicValuesBus, PublicValuesBusMessage,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_verify_stark_host::pvs::{
     DeferralPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX, DEF_PVS_AIR_ID,

--- a/crates/continuations/src/circuit/inner/unset/air.rs
+++ b/crates/continuations/src/circuit/inner/unset/air.rs
@@ -1,9 +1,10 @@
 use std::borrow::Borrow;
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_recursion_circuit::bus::{PublicValuesBus, PublicValuesBusMessage};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/continuations/src/circuit/inner/verifier/air.rs
+++ b/crates/continuations/src/circuit/inner/verifier/air.rs
@@ -3,7 +3,7 @@ use std::{array::from_fn, borrow::Borrow};
 use openvm_circuit::arch::POSEIDON2_WIDTH;
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit::{
     bus::{
@@ -14,7 +14,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_verify_stark_host::pvs::{
     VerifierBasePvs, VerifierDefPvs, CONSTRAINT_EVAL_AIR_ID, CONSTRAINT_EVAL_CACHED_INDEX,

--- a/crates/continuations/src/circuit/inner/vm_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/vm_pvs/air.rs
@@ -1,13 +1,16 @@
 use std::borrow::Borrow;
 
 use openvm_circuit::system::connector::DEFAULT_SUSPEND_EXIT_CODE;
-use openvm_circuit_primitives::utils::{and, assert_array_eq, not};
+use openvm_circuit_primitives::{
+    utils::{and, assert_array_eq, not},
+    ColumnsAir,
+};
 use openvm_recursion_circuit::bus::{
     CachedCommitBus, CachedCommitBusMessage, PublicValuesBus, PublicValuesBusMessage,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{VmPvs, VM_PVS_AIR_ID};

--- a/crates/continuations/src/circuit/root/commit/air.rs
+++ b/crates/continuations/src/circuit/root/commit/air.rs
@@ -1,10 +1,10 @@
 use std::borrow::Borrow;
 
 use itertools::Itertools;
-use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit::{bus::Poseidon2CompressBus, utils::assert_zeros};
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};

--- a/crates/continuations/src/circuit/root/def_paths/air.rs
+++ b/crates/continuations/src/circuit/root/def_paths/air.rs
@@ -5,12 +5,12 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit::bus::Poseidon2CompressBus;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/continuations/src/circuit/root/memory/air.rs
+++ b/crates/continuations/src/circuit/root/memory/air.rs
@@ -3,11 +3,11 @@ use std::borrow::Borrow;
 use openvm_circuit::system::memory::{
     dimensions::MemoryDimensions, merkle::public_values::PUBLIC_VALUES_AS,
 };
-use openvm_circuit_primitives::SubAir;
+use openvm_circuit_primitives::{ColumnsAir, SubAir};
 use openvm_recursion_circuit::bus::Poseidon2CompressBus;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, p3_util::log2_strict_usize, BaseAirWithPublicValues, ColumnsAir,
+    interaction::InteractionBuilder, p3_util::log2_strict_usize, BaseAirWithPublicValues,
     PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use openvm_circuit::arch::{ExitCode, POSEIDON2_WIDTH};
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit::{
     bus::{
         CachedCommitBus, CachedCommitBusMessage, Poseidon2CompressBus, Poseidon2CompressMessage,
@@ -11,7 +11,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{

--- a/crates/continuations/src/tests/dummy.rs
+++ b/crates/continuations/src/tests/dummy.rs
@@ -1,11 +1,12 @@
 use std::{borrow::BorrowMut, sync::Arc};
 
 use eyre::Result;
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
     proof::Proof,
     prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
-    AirRef, ColumnsAir, PartitionedBaseAir, StarkEngine,
+    AirRef, PartitionedBaseAir, StarkEngine,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{
     BabyBearPoseidon2CpuEngine, DuplexSponge, DIGEST_SIZE, F,

--- a/crates/continuations/src/tests/mod.rs
+++ b/crates/continuations/src/tests/mod.rs
@@ -14,7 +14,7 @@ use openvm_rv32im_transpiler::{
     Rv32ITranspilerExtension, Rv32IoTranspilerExtension, Rv32MTranspilerExtension,
 };
 use openvm_stark_backend::{
-    keygen::types::MultiStarkVerifyingKey, proof::Proof, StarkEngine, SystemParams,
+    keygen::types::MultiStarkVerifyingKey, proof::Proof, AirRef, StarkEngine, SystemParams,
 };
 use openvm_stark_sdk::{
     config::{
@@ -219,7 +219,13 @@ fn test_internal_recursive_vk_stabilization(def_hook_cached_commit_set: bool) ->
     let config = test_rv32im_config();
 
     let engine = Engine::new(app_system_params());
-    let (_, app_vk) = engine.keygen(&config.create_airs()?.into_airs().collect_vec());
+    let (_, app_vk) = engine.keygen(
+        &config
+            .create_airs()?
+            .into_airs()
+            .map(|a| a as AirRef<_>)
+            .collect_vec(),
+    );
     let def_hook_cached_commit = def_hook_cached_commit_set.then_some([F::ZERO; DIGEST_SIZE]);
 
     const MAX_LEAF_NUM_PROOFS: usize = 3;

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_3b/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_neg/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_neg/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_ns/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_ns/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_sharp_uni/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_sharp_uni/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/eq_airs/eq_uni/air.rs
+++ b/crates/recursion/src/batch_constraint/eq_airs/eq_uni/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/expr_eval/constraints_folding/air.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/constraints_folding/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/expr_eval/dag_commit.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/dag_commit.rs
@@ -2,15 +2,13 @@ use core::borrow::Borrow;
 use std::{array::from_fn, sync::Arc};
 
 use itertools::{fold, Itertools};
-use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_poseidon2_air::{
     Poseidon2Config, Poseidon2SubAir, Poseidon2SubChip, Poseidon2SubCols,
     BABY_BEAR_POSEIDON2_SBOX_DEGREE, POSEIDON2_WIDTH,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
-use openvm_stark_backend::{
-    air_builders::sub::SubAirBuilder, interaction::InteractionBuilder, ColumnsAir,
-};
+use openvm_stark_backend::{air_builders::sub::SubAirBuilder, interaction::InteractionBuilder};
 use openvm_stark_sdk::config::baby_bear_poseidon2::{DIGEST_SIZE, F};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::{Field, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};

--- a/crates/recursion/src/batch_constraint/expr_eval/interactions_folding/air.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/interactions_folding/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/air.rs
+++ b/crates/recursion/src/batch_constraint/expr_eval/symbolic_expression/air.rs
@@ -1,11 +1,11 @@
 use core::array;
 use std::{borrow::Borrow, sync::Arc};
 
-use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder, interaction::InteractionBuilder, BaseAirWithPublicValues,
-    ColumnsAir, PartitionedBaseAir,
+    PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};

--- a/crates/recursion/src/batch_constraint/expression_claim/air.rs
+++ b/crates/recursion/src/batch_constraint/expression_claim/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/fractions_folder/air.rs
+++ b/crates/recursion/src/batch_constraint/fractions_folder/air.rs
@@ -1,9 +1,9 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/multilinear/air.rs
@@ -1,9 +1,9 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
+++ b/crates/recursion/src/batch_constraint/sumcheck/univariate/air.rs
@@ -3,11 +3,11 @@ use std::borrow::Borrow;
 use openvm_circuit_primitives::{
     is_equal::{IsEqSubAir, IsEqualAuxCols, IsEqualIo},
     utils::{assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/gkr/input/air.rs
+++ b/crates/recursion/src/gkr/input/air.rs
@@ -3,11 +3,11 @@ use core::borrow::Borrow;
 use openvm_circuit_primitives::{
     is_zero::{IsZeroAuxCols, IsZeroIo, IsZeroSubAir},
     utils::{assert_array_eq, not, or},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/gkr/layer/air.rs
+++ b/crates/recursion/src/gkr/layer/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/gkr/sumcheck/air.rs
+++ b/crates/recursion/src/gkr/sumcheck/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/gkr/xi_sampler/air.rs
+++ b/crates/recursion/src/gkr/xi_sampler/air.rs
@@ -1,10 +1,10 @@
 use core::borrow::Borrow;
 use std::convert::Into;
 
-use openvm_circuit_primitives::SubAir;
+use openvm_circuit_primitives::{ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/primitives/exp_bits_len/air.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/air.rs
@@ -1,8 +1,9 @@
 use core::borrow::Borrow;
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::BabyBear;

--- a/crates/recursion/src/primitives/exp_bits_len/tests.rs
+++ b/crates/recursion/src/primitives/exp_bits_len/tests.rs
@@ -1,6 +1,7 @@
 use core::borrow::Borrow;
 use std::borrow::BorrowMut;
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_cpu_backend::CpuBackend;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
@@ -9,7 +10,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
     utils::disable_debug_builder,
     verifier::VerifierError,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
 };
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F},
@@ -313,6 +314,7 @@ fn test_exp_bits_len_rejects_nonzero_terminal_tail_on_last_row() {
 mod cuda_tests {
     use std::sync::Arc;
 
+    use openvm_circuit_primitives::ColumnsAir;
     use openvm_cuda_backend::data_transporter::assert_eq_host_and_device_matrix;
 
     use super::*;

--- a/crates/recursion/src/primitives/pow/air.rs
+++ b/crates/recursion/src/primitives/pow/air.rs
@@ -1,9 +1,10 @@
 use core::borrow::Borrow;
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, p3_util::log2_strict_usize, BaseAirWithPublicValues,
-    ColumnsAir, PartitionedBaseAir,
+    PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/recursion/src/primitives/range/air.rs
+++ b/crates/recursion/src/primitives/range/air.rs
@@ -1,8 +1,9 @@
 use core::borrow::Borrow;
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::PrimeCharacteristicRing;

--- a/crates/recursion/src/proof_shape/proof_shape/air.rs
+++ b/crates/recursion/src/proof_shape/proof_shape/air.rs
@@ -4,11 +4,11 @@ use itertools::fold;
 use openvm_circuit_primitives::{
     encoder::Encoder,
     utils::{and, not, or, select},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/proof_shape/pvs/air.rs
+++ b/crates/recursion/src/proof_shape/pvs/air.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::not, AlignedBorrow, SubAir};
+use openvm_circuit_primitives::{utils::not, AlignedBorrow, ColumnsAir, SubAir};
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField32};

--- a/crates/recursion/src/stacking/claims/air.rs
+++ b/crates/recursion/src/stacking/claims/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/stacking/eq_base/air.rs
+++ b/crates/recursion/src/stacking/eq_base/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not, or},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/stacking/eq_bits/air.rs
+++ b/crates/recursion/src/stacking/eq_bits/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/stacking/opening/air.rs
+++ b/crates/recursion/src/stacking/opening/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not, or},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/stacking/sumcheck/air.rs
+++ b/crates/recursion/src/stacking/sumcheck/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/stacking/univariate/air.rs
+++ b/crates/recursion/src/stacking/univariate/air.rs
@@ -2,11 +2,11 @@ use std::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/subairs/nested_for_loop/tests.rs
+++ b/crates/recursion/src/subairs/nested_for_loop/tests.rs
@@ -2,7 +2,7 @@
 
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::SubAir;
+use openvm_circuit_primitives::{ColumnsAir, SubAir};
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{
     any_air_arc_vec,
@@ -12,8 +12,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, DeviceDataTransporter, ProvingContext},
     utils::disable_debug_builder,
     verifier::VerifierError,
-    AirRef, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkEngine,
-    StarkProtocolConfig,
+    AirRef, BaseAirWithPublicValues, PartitionedBaseAir, StarkEngine, StarkProtocolConfig,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
 

--- a/crates/recursion/src/transcript/merkle_verify/air.rs
+++ b/crates/recursion/src/transcript/merkle_verify/air.rs
@@ -1,9 +1,10 @@
 use core::{array, borrow::Borrow};
 
+use openvm_circuit_primitives::ColumnsAir;
 pub use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{CHUNK, DIGEST_SIZE};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/transcript/poseidon2.rs
+++ b/crates/recursion/src/transcript/poseidon2.rs
@@ -1,13 +1,14 @@
 use core::borrow::Borrow;
 use std::{array::from_fn, sync::Arc};
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_poseidon2_air::{
     Poseidon2SubAir, Poseidon2SubCols, BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::sub::SubAirBuilder, interaction::InteractionBuilder, BaseAirWithPublicValues,
-    ColumnsAir, PartitionedBaseAir,
+    PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::Field;

--- a/crates/recursion/src/transcript/transcript/air.rs
+++ b/crates/recursion/src/transcript/transcript/air.rs
@@ -2,11 +2,11 @@ use core::borrow::Borrow;
 
 use openvm_circuit_primitives::{
     utils::{and, assert_array_eq, not, or},
-    SubAir,
+    ColumnsAir, SubAir,
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{Field, PrimeCharacteristicRing};

--- a/crates/recursion/src/whir/final_poly_mle_eval/air.rs
+++ b/crates/recursion/src/whir/final_poly_mle_eval/air.rs
@@ -8,10 +8,10 @@
 
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::utils::assert_array_eq;
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/final_poly_query_eval/air.rs
+++ b/crates/recursion/src/whir/final_poly_query_eval/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/folding/air.rs
+++ b/crates/recursion/src/whir/folding/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::utils::assert_array_eq;
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -1,10 +1,10 @@
 use core::{array, borrow::Borrow};
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{CHUNK, D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/non_initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/non_initial_opened_values/air.rs
@@ -1,11 +1,11 @@
 use core::borrow::Borrow;
 use std::array::from_fn;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_poseidon2_air::POSEIDON2_WIDTH;
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{CHUNK, D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/query/air.rs
+++ b/crates/recursion/src/whir/query/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/sumcheck/air.rs
+++ b/crates/recursion/src/whir/sumcheck/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/recursion/src/whir/whir_round/air.rs
+++ b/crates/recursion/src/whir/whir_round/air.rs
@@ -1,9 +1,9 @@
 use core::borrow::Borrow;
 
-use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{encoder::Encoder, utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{DIGEST_SIZE, D_EF, F};
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/crates/sdk/src/keygen/mod.rs
+++ b/crates/sdk/src/keygen/mod.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 use openvm_continuations::RootSC;
 use openvm_stark_backend::{
     keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey},
-    StarkEngine,
+    AirRef, StarkEngine,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine, DuplexSponge};
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,7 @@ where
                         .app_vm_config
                         .create_airs()?
                         .into_airs()
+                        .map(|a| a as AirRef<_>)
                         .collect_vec(),
                 )
                 .0;

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -18,14 +18,14 @@ use std::{
 use getset::{CopyGetters, Getters};
 use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerAir},
-    AnyChip, Chip,
+    AnyChip, Chip, ColumnsAir,
 };
 use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{PhantomDiscriminant, VmOpcode};
 use openvm_stark_backend::{
     interaction::BusIndex,
     prover::{AirProvingContext, MatrixDimensions, ProverBackend, ProvingContext},
-    AirRef, AnyAir, StarkEngine, StarkProtocolConfig, Val,
+    AnyAir, StarkEngine, StarkProtocolConfig, Val,
 };
 use rustc_hash::FxHashMap;
 use tracing::info_span;
@@ -54,6 +54,26 @@ pub const BOUNDARY_AIR_ID: usize = MEMORY_AIRS_START_IDX + BOUNDARY_AIR_OFFSET;
 pub const MERKLE_AIR_ID: usize = MEMORY_AIRS_START_IDX + MERKLE_AIR_OFFSET;
 
 pub type ExecutorId = u32;
+
+/// AIR trait object combining [`AnyAir`] (used by stark-backend for proving) with
+/// [`ColumnsAir`] (OpenVM-internal column-name introspection used by external tooling). The
+/// blanket impl below makes every type satisfying both traits also satisfy this one, so existing
+/// concrete AIRs need no changes.
+///
+/// Trait upcasting (stable since Rust 1.86) coerces `Arc<dyn AnyAirWithColumns<SC>>` to
+/// `Arc<dyn AnyAir<SC>>` in argument position, so [`AirRefWithColumns`] passes transparently to
+/// stark-backend APIs that expect [`AirRef`](openvm_stark_backend::AirRef).
+pub trait AnyAirWithColumns<SC: StarkProtocolConfig>: AnyAir<SC> + ColumnsAir<Val<SC>> {}
+
+impl<SC, T> AnyAirWithColumns<SC> for T
+where
+    SC: StarkProtocolConfig,
+    T: AnyAir<SC> + ColumnsAir<Val<SC>>,
+{
+}
+
+/// Reference-counted dyn pointer to an AIR with column-name introspection.
+pub type AirRefWithColumns<SC> = Arc<dyn AnyAirWithColumns<SC>>;
 
 // ======================= VM Extension Traits =============================
 
@@ -138,7 +158,7 @@ pub struct AirInventory<SC: StarkProtocolConfig> {
     /// Note that the system will ensure that the first AIR in the list is always the
     /// [VariableRangeCheckerAir].
     #[get = "pub"]
-    ext_airs: Vec<AirRef<SC>>,
+    ext_airs: Vec<AirRefWithColumns<SC>>,
     /// `ext_start[i]` will have the starting index in `ext_airs` for extension `i`
     ext_start: Vec<usize>,
 
@@ -427,11 +447,11 @@ impl<SC: StarkProtocolConfig> AirInventory<SC> {
             .filter_map(|air| air.as_any().downcast_ref())
     }
 
-    pub fn add_air<A: AnyAir<SC> + 'static>(&mut self, air: A) {
+    pub fn add_air<A: AnyAirWithColumns<SC> + 'static>(&mut self, air: A) {
         self.add_air_ref(Arc::new(air));
     }
 
-    pub fn add_air_ref(&mut self, air: AirRef<SC>) {
+    pub fn add_air_ref(&mut self, air: AirRefWithColumns<SC>) {
         self.ext_airs.push(air);
     }
 
@@ -445,7 +465,7 @@ impl<SC: StarkProtocolConfig> AirInventory<SC> {
     /// This is the system AIRs, followed by the other AIRs in the **reverse** of the order they
     /// were added in the VM extension definitions. In particular, the AIRs that have dependencies
     /// appear later. The system guarantees that the last AIR is the [VariableRangeCheckerAir].
-    pub fn into_airs(self) -> impl Iterator<Item = AirRef<SC>> {
+    pub fn into_airs(self) -> impl Iterator<Item = AirRefWithColumns<SC>> {
         self.system
             .into_airs()
             .into_iter()

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -1,6 +1,6 @@
 use std::{array::from_fn, borrow::Borrow, marker::PhantomData};
 
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
@@ -10,7 +10,7 @@ use openvm_stark_backend::{
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/vm/src/arch/testing/execution/air.rs
+++ b/crates/vm/src/arch/testing/execution/air.rs
@@ -1,13 +1,13 @@
 use std::{borrow::Borrow, mem::size_of};
 
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
     p3_field::Field,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::arch::{ExecutionBus, ExecutionState};

--- a/crates/vm/src/arch/testing/memory/air.rs
+++ b/crates/vm/src/arch/testing/memory/air.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use openvm_circuit_primitives::Chip;
+use openvm_circuit_primitives::{Chip, ColumnsAir};
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -8,7 +8,7 @@ use openvm_stark_backend::{
     p3_field::{PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 
 use crate::{

--- a/crates/vm/src/arch/testing/program/air.rs
+++ b/crates/vm/src/arch/testing/program/air.rs
@@ -1,9 +1,10 @@
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
     p3_field::Field,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::ProgramTester;

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -30,7 +30,7 @@ use openvm_stark_backend::{
         MatrixDimensions, ProverBackend, ProvingContext, TraceCommitter,
     },
     verifier::VerifierError,
-    Com, StarkEngine, StarkProtocolConfig, Val,
+    AirRef, Com, StarkEngine, StarkProtocolConfig, Val,
 };
 use p3_baby_bear::BabyBear;
 use serde::{Deserialize, Serialize};
@@ -1340,6 +1340,6 @@ where
     VB: VmBuilder<E>,
 {
     let air_inv = vm.config().create_airs().unwrap();
-    let global_airs = air_inv.into_airs().collect_vec();
+    let global_airs: Vec<AirRef<E::SC>> = air_inv.into_airs().map(|a| a as AirRef<_>).collect();
     vm.engine.debug(&global_airs, ctx);
 }

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    ColumnsAir, StructReflection, StructReflectionHelper,
+    StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
@@ -77,11 +77,7 @@ impl<F: Field> BaseAirWithPublicValues<F> for VmConnectorAir {
     }
 }
 impl<F: Field> PartitionedBaseAir<F> for VmConnectorAir {}
-impl<F: Field> ColumnsAir<F> for VmConnectorAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <ConnectorCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(VmConnectorAir, ConnectorCols<F>);
 impl<F: Field> BaseAir<F> for VmConnectorAir {
     fn width(&self) -> usize {
         ConnectorCols::<F>::width()

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use openvm_circuit_primitives::{
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
@@ -77,7 +77,11 @@ impl<F: Field> BaseAirWithPublicValues<F> for VmConnectorAir {
     }
 }
 impl<F: Field> PartitionedBaseAir<F> for VmConnectorAir {}
-openvm_circuit_primitives::impl_columns_air!(VmConnectorAir, ConnectorCols<F>);
+impl<F: Field> ColumnsAir<F> for VmConnectorAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <ConnectorCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAir<F> for VmConnectorAir {
     fn width(&self) -> usize {
         ConnectorCols::<F>::width()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Borrow, iter};
 
-use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir},
@@ -19,11 +18,7 @@ pub struct MemoryMerkleAir<const CHUNK: usize> {
 }
 
 impl<const CHUNK: usize, F: Field> PartitionedBaseAir<F> for MemoryMerkleAir<CHUNK> {}
-impl<const CHUNK: usize, F: Field> ColumnsAir<F> for MemoryMerkleAir<CHUNK> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <MemoryMerkleCols<F, CHUNK> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!([const CHUNK: usize] MemoryMerkleAir<CHUNK>, MemoryMerkleCols<F, CHUNK>);
 impl<const CHUNK: usize, F: Field> BaseAir<F> for MemoryMerkleAir<CHUNK> {
     fn width(&self) -> usize {
         MemoryMerkleCols::<F, CHUNK>::width()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Borrow, iter};
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir},
@@ -18,7 +19,11 @@ pub struct MemoryMerkleAir<const CHUNK: usize> {
 }
 
 impl<const CHUNK: usize, F: Field> PartitionedBaseAir<F> for MemoryMerkleAir<CHUNK> {}
-openvm_circuit_primitives::impl_columns_air!([const CHUNK: usize] MemoryMerkleAir<CHUNK>, MemoryMerkleCols<F, CHUNK>);
+impl<const CHUNK: usize, F: Field> ColumnsAir<F> for MemoryMerkleAir<CHUNK> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <MemoryMerkleCols<F, CHUNK> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<const CHUNK: usize, F: Field> BaseAir<F> for MemoryMerkleAir<CHUNK> {
     fn width(&self) -> usize {
         MemoryMerkleCols::<F, CHUNK>::width()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -1,11 +1,12 @@
 use std::{borrow::Borrow, iter};
 
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_stark_backend::{
     interaction::{InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::system::memory::merkle::{MemoryDimensions, MemoryMerkleCols, MemoryMerklePvs};

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::PermutationCheckBus, p3_util::log2_strict_usize, AirRef, StarkProtocolConfig,
+    interaction::PermutationCheckBus, p3_util::log2_strict_usize, StarkProtocolConfig,
 };
 
 mod controller;
@@ -18,7 +18,7 @@ pub use controller::*;
 pub use online::{Address, AddressMap, INITIAL_TIMESTAMP};
 
 use crate::{
-    arch::MemoryConfig,
+    arch::{AirRefWithColumns, MemoryConfig},
     system::memory::{
         dimensions::MemoryDimensions, interface::MemoryInterfaceAirs, merkle::MemoryMerkleAir,
         offline_checker::MemoryBridge, persistent::PersistentBoundaryAir,
@@ -98,7 +98,7 @@ impl MemoryAirInventory {
     }
 
     /// The order of memory AIRs is boundary, merkle (if exists)
-    pub fn into_airs<SC: StarkProtocolConfig>(self) -> Vec<AirRef<SC>> {
+    pub fn into_airs<SC: StarkProtocolConfig>(self) -> Vec<AirRefWithColumns<SC>> {
         vec![
             Arc::new(self.interface.boundary),
             Arc::new(self.interface.merkle),

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -4,7 +4,7 @@ use std::{
     iter,
 };
 
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{
@@ -76,7 +76,11 @@ impl<const CHUNK: usize, F> BaseAir<F> for PersistentBoundaryAir<CHUNK> {
 
 impl<const CHUNK: usize, F> BaseAirWithPublicValues<F> for PersistentBoundaryAir<CHUNK> {}
 impl<const CHUNK: usize, F> PartitionedBaseAir<F> for PersistentBoundaryAir<CHUNK> {}
-openvm_circuit_primitives::impl_columns_air!([const CHUNK: usize] PersistentBoundaryAir<CHUNK>, PersistentBoundaryCols<F, CHUNK>);
+impl<const CHUNK: usize, F> ColumnsAir<F> for PersistentBoundaryAir<CHUNK> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <PersistentBoundaryCols<F, CHUNK> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<const CHUNK: usize, AB: InteractionBuilder> Air<AB> for PersistentBoundaryAir<CHUNK> {
     fn eval(&self, builder: &mut AB) {

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -4,7 +4,7 @@ use std::{
     iter,
 };
 
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{
@@ -14,7 +14,7 @@ use openvm_stark_backend::{
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
     prover::AirProvingContext,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir, StarkProtocolConfig, Val,
+    BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
 use rustc_hash::FxHashSet;
 use tracing::instrument;

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -4,7 +4,7 @@ use std::{
     iter,
 };
 
-use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::{
@@ -76,11 +76,7 @@ impl<const CHUNK: usize, F> BaseAir<F> for PersistentBoundaryAir<CHUNK> {
 
 impl<const CHUNK: usize, F> BaseAirWithPublicValues<F> for PersistentBoundaryAir<CHUNK> {}
 impl<const CHUNK: usize, F> PartitionedBaseAir<F> for PersistentBoundaryAir<CHUNK> {}
-impl<const CHUNK: usize, F> ColumnsAir<F> for PersistentBoundaryAir<CHUNK> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <PersistentBoundaryCols<F, CHUNK> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!([const CHUNK: usize] PersistentBoundaryAir<CHUNK>, PersistentBoundaryCols<F, CHUNK>);
 
 impl<const CHUNK: usize, AB: InteractionBuilder> Air<AB> for PersistentBoundaryAir<CHUNK> {
     fn eval(&self, builder: &mut AB) {

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -17,18 +17,19 @@ use openvm_stark_backend::{
     interaction::{LookupBus, PermutationCheckBus},
     p3_field::{Field, PrimeField32},
     prover::{AirProvingContext, CommittedTraceData, ProverBackend},
-    AirRef, StarkEngine, StarkProtocolConfig, Val,
+    StarkEngine, StarkProtocolConfig, Val,
 };
 use rustc_hash::FxHashMap;
 
 use self::{connector::VmConnectorAir, program::ProgramAir};
 use crate::{
     arch::{
-        vm_poseidon2_config, AirInventory, AirInventoryError, BusIndexManager, ChipInventory,
-        ChipInventoryError, ExecutionBridge, ExecutionBus, ExecutionState, ExecutorInventory,
-        ExecutorInventoryError, MatrixRecordArena, PhantomSubExecutor, RowMajorMatrixArena,
-        SystemConfig, VmBuilder, VmChipComplex, VmCircuitConfig, VmExecutionConfig, VmField,
-        BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, DEFAULT_BLOCK_SIZE, PROGRAM_AIR_ID,
+        vm_poseidon2_config, AirInventory, AirInventoryError, AirRefWithColumns, BusIndexManager,
+        ChipInventory, ChipInventoryError, ExecutionBridge, ExecutionBus, ExecutionState,
+        ExecutorInventory, ExecutorInventoryError, MatrixRecordArena, PhantomSubExecutor,
+        RowMajorMatrixArena, SystemConfig, VmBuilder, VmChipComplex, VmCircuitConfig,
+        VmExecutionConfig, VmField, BOUNDARY_AIR_ID, CONNECTOR_AIR_ID, DEFAULT_BLOCK_SIZE,
+        PROGRAM_AIR_ID,
     },
     system::{
         connector::VmConnectorChip,
@@ -176,8 +177,8 @@ impl SystemAirInventory {
         }
     }
 
-    pub fn into_airs<SC: StarkProtocolConfig>(self) -> Vec<AirRef<SC>> {
-        let mut airs: Vec<AirRef<SC>> = Vec::new();
+    pub fn into_airs<SC: StarkProtocolConfig>(self) -> Vec<AirRefWithColumns<SC>> {
+        let mut airs: Vec<AirRefWithColumns<SC>> = Vec::new();
         airs.push(Arc::new(self.program));
         airs.push(Arc::new(self.connector));
         airs.extend(self.memory.into_airs());

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -7,9 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use openvm_circuit_primitives::{
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
-};
+use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, PhantomDiscriminant, SysPhantom,
@@ -69,11 +67,7 @@ impl<F: Field> BaseAir<F> for PhantomAir {
     }
 }
 impl<F: Field> PartitionedBaseAir<F> for PhantomAir {}
-impl<F: Field> ColumnsAir<F> for PhantomAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <PhantomCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(PhantomAir, PhantomCols<F>);
 impl<F: Field> BaseAirWithPublicValues<F> for PhantomAir {}
 
 impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -7,7 +7,9 @@ use std::{
     sync::Arc,
 };
 
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, PhantomDiscriminant, SysPhantom,
@@ -67,7 +69,11 @@ impl<F: Field> BaseAir<F> for PhantomAir {
     }
 }
 impl<F: Field> PartitionedBaseAir<F> for PhantomAir {}
-openvm_circuit_primitives::impl_columns_air!(PhantomAir, PhantomCols<F>);
+impl<F: Field> ColumnsAir<F> for PhantomAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <PhantomCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAirWithPublicValues<F> for PhantomAir {}
 
 impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -7,7 +7,9 @@ use std::{
     sync::Arc,
 };
 
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, PhantomDiscriminant, SysPhantom,
@@ -18,7 +20,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use rand::rngs::StdRng;
 use rustc_hash::FxHashMap;

--- a/crates/vm/src/system/poseidon2/air.rs
+++ b/crates/vm/src/system/poseidon2/air.rs
@@ -1,6 +1,7 @@
 use std::{array::from_fn, borrow::Borrow, sync::Arc};
 
 use derive_new::new;
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_poseidon2_air::{
     Poseidon2SubAir, BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS, POSEIDON2_WIDTH,
 };
@@ -10,7 +11,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::Field,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::columns::Poseidon2PeripheryCols;

--- a/crates/vm/src/system/poseidon2/mod.rs
+++ b/crates/vm/src/system/poseidon2/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use openvm_circuit_primitives::Chip;
 use openvm_poseidon2_air::{Poseidon2Config, Poseidon2SubAir};
-use openvm_stark_backend::{interaction::LookupBus, AirRef, StarkProtocolConfig, Val};
+use openvm_stark_backend::{interaction::LookupBus, StarkProtocolConfig, Val};
 
 #[cfg(test)]
 pub mod tests;
@@ -25,7 +25,7 @@ pub use chip::*;
 use crate::{
     arch::{
         hasher::{Hasher, HasherChip},
-        VmField,
+        AirRefWithColumns, VmField,
     },
     system::poseidon2::air::Poseidon2PeripheryAir,
 };
@@ -55,7 +55,7 @@ pub fn new_poseidon2_periphery_air<SC>(
     poseidon2_config: Poseidon2Config<Val<SC>>,
     direct_bus: LookupBus,
     max_constraint_degree: usize,
-) -> AirRef<SC>
+) -> AirRefWithColumns<SC>
 where
     SC: StarkProtocolConfig,
     Val<SC>: VmField,

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -1,4 +1,4 @@
-use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder,
@@ -47,11 +47,7 @@ impl<F: Field> PartitionedBaseAir<F> for ProgramAir {
         1
     }
 }
-impl<F: Field> ColumnsAir<F> for ProgramAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <ProgramCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(ProgramAir, ProgramCols<F>);
 impl<F: Field> BaseAir<F> for ProgramAir {
     fn width(&self) -> usize {
         ProgramCols::<F>::width()

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -1,4 +1,4 @@
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder,
@@ -6,7 +6,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::Field,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::ProgramBus;

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -1,4 +1,4 @@
-use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::PartitionedAirBuilder,
@@ -47,7 +47,11 @@ impl<F: Field> PartitionedBaseAir<F> for ProgramAir {
         1
     }
 }
-openvm_circuit_primitives::impl_columns_air!(ProgramAir, ProgramCols<F>);
+impl<F: Field> ColumnsAir<F> for ProgramAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <ProgramCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F: Field> BaseAir<F> for ProgramAir {
     fn width(&self) -> usize {
         ProgramCols::<F>::width()

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -16,7 +16,8 @@ use openvm_circuit_primitives::{
     bigint::utils::big_uint_to_limbs,
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     is_equal_array::{IsEqArrayIo, IsEqArraySubAir},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper, SubAir, TraceSubRowGenerator,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
+    TraceSubRowGenerator,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -112,11 +113,13 @@ impl<F: Field, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BIT
     BaseAirWithPublicValues<F> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize]
-    ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>,
-    ModularIsEqualCoreCols<F, READ_LIMBS>
-);
+impl<F: Field, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
+    ColumnsAir<F> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <ModularIsEqualCoreCols<F, READ_LIMBS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
     VmCoreAir<AB, I> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -16,7 +16,8 @@ use openvm_circuit_primitives::{
     bigint::utils::big_uint_to_limbs,
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     is_equal_array::{IsEqArrayIo, IsEqArraySubAir},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper, SubAir, TraceSubRowGenerator,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
+    TraceSubRowGenerator,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -30,7 +31,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::modular_chip::VmModularIsEqualExecutor;

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -16,8 +16,7 @@ use openvm_circuit_primitives::{
     bigint::utils::big_uint_to_limbs,
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     is_equal_array::{IsEqArrayIo, IsEqArraySubAir},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper, SubAir,
-    TraceSubRowGenerator,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper, SubAir, TraceSubRowGenerator,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -113,13 +112,11 @@ impl<F: Field, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BIT
     BaseAirWithPublicValues<F> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
-    ColumnsAir<F> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <ModularIsEqualCoreCols<F, READ_LIMBS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize]
+    ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>,
+    ModularIsEqualCoreCols<F, READ_LIMBS>
+);
 
 impl<AB, I, const READ_LIMBS: usize, const WRITE_LIMBS: usize, const LIMB_BITS: usize>
     VmCoreAir<AB, I> for ModularIsEqualCoreAir<READ_LIMBS, WRITE_LIMBS, LIMB_BITS>

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -261,11 +261,7 @@ impl<F: Field> BaseAir<F> for DeferralCallAdapterAir {
         DeferralCallAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for DeferralCallAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        None
-    }
-}
+impl<F: Field> ColumnsAir<F> for DeferralCallAdapterAir {}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
     type Interface = DeferralCallAdapterInterface;

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -261,7 +261,11 @@ impl<F: Field> BaseAir<F> for DeferralCallAdapterAir {
         DeferralCallAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for DeferralCallAdapterAir {}
+impl<F: Field> ColumnsAir<F> for DeferralCallAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        None
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
     type Interface = DeferralCallAdapterInterface;

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -12,7 +12,8 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    bitwise_op_lookup::BitwiseOperationLookupBus, StructReflection, StructReflectionHelper,
+    bitwise_op_lookup::BitwiseOperationLookupBus, ColumnsAir, StructReflection,
+    StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
@@ -25,7 +26,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_field::PrimeField32;

--- a/extensions/deferral/circuit/src/count/air.rs
+++ b/extensions/deferral/circuit/src/count/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -33,11 +33,7 @@ impl<F> BaseAir<F> for DeferralCircuitCountAir {
 }
 impl<F> BaseAirWithPublicValues<F> for DeferralCircuitCountAir {}
 impl<F> PartitionedBaseAir<F> for DeferralCircuitCountAir {}
-impl<F> ColumnsAir<F> for DeferralCircuitCountAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <DeferralCircuitCountCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(DeferralCircuitCountAir, DeferralCircuitCountCols<F>);
 
 impl<AB> Air<AB> for DeferralCircuitCountAir
 where

--- a/extensions/deferral/circuit/src/count/air.rs
+++ b/extensions/deferral/circuit/src/count/air.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -33,7 +33,11 @@ impl<F> BaseAir<F> for DeferralCircuitCountAir {
 }
 impl<F> BaseAirWithPublicValues<F> for DeferralCircuitCountAir {}
 impl<F> PartitionedBaseAir<F> for DeferralCircuitCountAir {}
-openvm_circuit_primitives::impl_columns_air!(DeferralCircuitCountAir, DeferralCircuitCountCols<F>);
+impl<F> ColumnsAir<F> for DeferralCircuitCountAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <DeferralCircuitCountCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB> Air<AB> for DeferralCircuitCountAir
 where

--- a/extensions/deferral/circuit/src/count/air.rs
+++ b/extensions/deferral/circuit/src/count/air.rs
@@ -1,13 +1,13 @@
 use std::borrow::Borrow;
 
-use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::DeferralCircuitCountBus;

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::BitwiseOperationLookupBus,
     utils::{assert_array_eq, not},
-    StructReflection, StructReflectionHelper,
+    ColumnsAir,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
@@ -25,7 +25,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_field::PrimeField32;

--- a/extensions/deferral/circuit/src/poseidon2/air.rs
+++ b/extensions/deferral/circuit/src/poseidon2/air.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, iter::once, sync::Arc};
 
-use openvm_circuit_primitives::AlignedBorrow;
+use openvm_circuit_primitives::{AlignedBorrow, ColumnsAir};
 use openvm_poseidon2_air::{
     Poseidon2Config, Poseidon2SubAir, Poseidon2SubCols, BABY_BEAR_POSEIDON2_HALF_FULL_ROUNDS,
 };
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     interaction::{InteractionBuilder, LookupBus},
     p3_air::{Air, AirBuilder, BaseAir},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_field::{Field, PrimeCharacteristicRing};

--- a/extensions/keccak256/circuit/src/keccakf_op/air.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/air.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
+use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, ColumnsAir};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     p3_air::{Air, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::{

--- a/extensions/keccak256/circuit/src/keccakf_op/air.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/air.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, ColumnsAir};
+use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -43,11 +43,7 @@ pub struct KeccakfOpAir {
 
 impl<F> BaseAirWithPublicValues<F> for KeccakfOpAir {}
 impl<F> PartitionedBaseAir<F> for KeccakfOpAir {}
-impl<F> ColumnsAir<F> for KeccakfOpAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <KeccakfOpCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(KeccakfOpAir, KeccakfOpCols<F>);
 impl<F> BaseAir<F> for KeccakfOpAir {
     fn width(&self) -> usize {
         NUM_KECCAKF_OP_COLS

--- a/extensions/keccak256/circuit/src/keccakf_op/air.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/air.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::bitwise_op_lookup::BitwiseOperationLookupBus;
+use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, ColumnsAir};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -43,7 +43,11 @@ pub struct KeccakfOpAir {
 
 impl<F> BaseAirWithPublicValues<F> for KeccakfOpAir {}
 impl<F> PartitionedBaseAir<F> for KeccakfOpAir {}
-openvm_circuit_primitives::impl_columns_air!(KeccakfOpAir, KeccakfOpCols<F>);
+impl<F> ColumnsAir<F> for KeccakfOpAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <KeccakfOpCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F> BaseAir<F> for KeccakfOpAir {
     fn width(&self) -> usize {
         NUM_KECCAKF_OP_COLS

--- a/extensions/keccak256/circuit/src/keccakf_perm/air.rs
+++ b/extensions/keccak256/circuit/src/keccakf_perm/air.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, iter};
 
-use openvm_circuit_primitives::StructReflectionHelper;
+use openvm_circuit_primitives::{ColumnsAir, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_stark_backend::{
     air_builders::sub::SubAirBuilder,
@@ -8,7 +8,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use p3_keccak_air::{KeccakAir, KeccakCols, NUM_KECCAK_COLS, U64_LIMBS};
 

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -8,9 +8,7 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::{
-    bitwise_op_lookup::BitwiseOperationLookupBus, utils::not, ColumnsAir,
-};
+use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, utils::not};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -38,11 +36,7 @@ pub struct XorinVmAir {
 
 impl<F> BaseAirWithPublicValues<F> for XorinVmAir {}
 impl<F> PartitionedBaseAir<F> for XorinVmAir {}
-impl<F> ColumnsAir<F> for XorinVmAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <XorinVmCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(XorinVmAir, XorinVmCols<F>);
 impl<F> BaseAir<F> for XorinVmAir {
     fn width(&self) -> usize {
         NUM_XORIN_VM_COLS

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -8,7 +8,9 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, utils::not};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupBus, utils::not, ColumnsAir,
+};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -36,7 +38,11 @@ pub struct XorinVmAir {
 
 impl<F> BaseAirWithPublicValues<F> for XorinVmAir {}
 impl<F> PartitionedBaseAir<F> for XorinVmAir {}
-openvm_circuit_primitives::impl_columns_air!(XorinVmAir, XorinVmCols<F>);
+impl<F> ColumnsAir<F> for XorinVmAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <XorinVmCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 impl<F> BaseAir<F> for XorinVmAir {
     fn width(&self) -> usize {
         NUM_XORIN_VM_COLS

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -8,7 +8,9 @@ use openvm_circuit::{
         MemoryAddress,
     },
 };
-use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, utils::not};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupBus, utils::not, ColumnsAir,
+};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -18,7 +20,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::xorin::columns::{XorinVmCols, NUM_XORIN_VM_COLS};

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -35,7 +35,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers and writes to a register.

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -90,16 +90,19 @@ impl<
     }
 }
 
-openvm_circuit_primitives::impl_columns_air!(
-    [
+impl<
+        F: Field,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    ]
-    Rv32IsEqualModAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>,
-    Rv32IsEqualModAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE>
-);
+    > ColumnsAir<F>
+    for Rv32IsEqualModAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32IsEqualModAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/eq_mod.rs
+++ b/extensions/rv32-adapters/src/eq_mod.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -90,19 +90,16 @@ impl<
     }
 }
 
-impl<
-        F: Field,
+openvm_circuit_primitives::impl_columns_air!(
+    [
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCK_SIZE: usize,
         const TOTAL_READ_SIZE: usize,
-    > ColumnsAir<F>
-    for Rv32IsEqualModAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32IsEqualModAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+    ]
+    Rv32IsEqualModAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE, TOTAL_READ_SIZE>,
+    Rv32IsEqualModAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCK_SIZE>
+);
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -21,7 +21,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -108,17 +108,27 @@ impl<
     }
 }
 
-openvm_circuit_primitives::impl_columns_air!(
-    [
+impl<
+        F: Field,
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    ]
-    Rv32VecHeapAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>,
-    Rv32VecHeapAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
-);
+    > ColumnsAir<F>
+    for Rv32VecHeapAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32VecHeapAdapterCols<
+            F,
+            NUM_READS,
+            BLOCKS_PER_READ,
+            BLOCKS_PER_WRITE,
+            READ_SIZE,
+            WRITE_SIZE,
+        > as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -21,7 +21,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -108,27 +108,17 @@ impl<
     }
 }
 
-impl<
-        F: Field,
+openvm_circuit_primitives::impl_columns_air!(
+    [
         const NUM_READS: usize,
         const BLOCKS_PER_READ: usize,
         const BLOCKS_PER_WRITE: usize,
         const READ_SIZE: usize,
         const WRITE_SIZE: usize,
-    > ColumnsAir<F>
-    for Rv32VecHeapAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32VecHeapAdapterCols<
-            F,
-            NUM_READS,
-            BLOCKS_PER_READ,
-            BLOCKS_PER_WRITE,
-            READ_SIZE,
-            WRITE_SIZE,
-        > as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+    ]
+    Rv32VecHeapAdapterAir<NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>,
+    Rv32VecHeapAdapterCols<F, NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, READ_SIZE, WRITE_SIZE>
+);
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/vec_heap.rs
+++ b/extensions/rv32-adapters/src/vec_heap.rs
@@ -21,7 +21,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -36,7 +36,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 /// This adapter reads from R (R <= 2) pointers and writes to 1 pointer.

--- a/extensions/rv32-adapters/src/vec_heap_branch.rs
+++ b/extensions/rv32-adapters/src/vec_heap_branch.rs
@@ -18,7 +18,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -33,7 +33,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 /// This adapter reads from NUM_READS <= 2 pointers (for branch operations).

--- a/extensions/rv32-adapters/src/vec_heap_branch.rs
+++ b/extensions/rv32-adapters/src/vec_heap_branch.rs
@@ -18,7 +18,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -80,13 +80,11 @@ impl<F: Field, const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_
     }
 }
 
-impl<F: Field, const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_SIZE: usize>
-    ColumnsAir<F> for Rv32VecHeapBranchAdapterAir<NUM_READS, BLOCKS_PER_READ, READ_SIZE>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32VecHeapBranchAdapterCols<F, NUM_READS, BLOCKS_PER_READ, READ_SIZE> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_SIZE: usize]
+    Rv32VecHeapBranchAdapterAir<NUM_READS, BLOCKS_PER_READ, READ_SIZE>,
+    Rv32VecHeapBranchAdapterCols<F, NUM_READS, BLOCKS_PER_READ, READ_SIZE>
+);
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/vec_heap_branch.rs
+++ b/extensions/rv32-adapters/src/vec_heap_branch.rs
@@ -18,7 +18,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -80,11 +80,13 @@ impl<F: Field, const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_
     }
 }
 
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_SIZE: usize]
-    Rv32VecHeapBranchAdapterAir<NUM_READS, BLOCKS_PER_READ, READ_SIZE>,
-    Rv32VecHeapBranchAdapterCols<F, NUM_READS, BLOCKS_PER_READ, READ_SIZE>
-);
+impl<F: Field, const NUM_READS: usize, const BLOCKS_PER_READ: usize, const READ_SIZE: usize>
+    ColumnsAir<F> for Rv32VecHeapBranchAdapterAir<NUM_READS, BLOCKS_PER_READ, READ_SIZE>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32VecHeapBranchAdapterCols<F, NUM_READS, BLOCKS_PER_READ, READ_SIZE> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<
         AB: InteractionBuilder,

--- a/extensions/rv32-adapters/src/vec_to_flat.rs
+++ b/extensions/rv32-adapters/src/vec_to_flat.rs
@@ -11,10 +11,11 @@ use openvm_circuit::{
     },
     system::memory::online::TracingMemory,
 };
+use openvm_circuit_primitives::ColumnsAir;
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::{
     interaction::InteractionBuilder, p3_air::BaseAir, p3_field::PrimeField32,
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 // =================================================================================================

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -17,7 +17,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -64,7 +64,11 @@ impl<F: Field> BaseAir<F> for Rv32BaseAluAdapterAir {
         Rv32BaseAluAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32BaseAluAdapterAir, Rv32BaseAluAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32BaseAluAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32BaseAluAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -17,7 +17,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -29,7 +29,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::{

--- a/extensions/rv32im/circuit/src/adapters/alu.rs
+++ b/extensions/rv32im/circuit/src/adapters/alu.rs
@@ -17,7 +17,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -64,11 +64,7 @@ impl<F: Field> BaseAir<F> for Rv32BaseAluAdapterAir {
         Rv32BaseAluAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32BaseAluAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32BaseAluAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32BaseAluAdapterAir, Rv32BaseAluAdapterCols<F>);
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BaseAluAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -11,7 +11,9 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -20,7 +22,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -11,9 +11,7 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
-};
+use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -47,11 +45,7 @@ impl<F: Field> BaseAir<F> for Rv32BranchAdapterAir {
         Rv32BranchAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32BranchAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32BranchAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32BranchAdapterAir, Rv32BranchAdapterCols<F>);
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BranchAdapterAir {
     type Interface =

--- a/extensions/rv32im/circuit/src/adapters/branch.rs
+++ b/extensions/rv32im/circuit/src/adapters/branch.rs
@@ -11,7 +11,9 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -45,7 +47,11 @@ impl<F: Field> BaseAir<F> for Rv32BranchAdapterAir {
         Rv32BranchAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32BranchAdapterAir, Rv32BranchAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32BranchAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32BranchAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32BranchAdapterAir {
     type Interface =

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -54,7 +54,11 @@ impl<F: Field> BaseAir<F> for Rv32JalrAdapterAir {
         Rv32JalrAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32JalrAdapterAir, Rv32JalrAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32JalrAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32JalrAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32JalrAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -54,11 +54,7 @@ impl<F: Field> BaseAir<F> for Rv32JalrAdapterAir {
         Rv32JalrAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32JalrAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32JalrAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32JalrAdapterAir, Rv32JalrAdapterCols<F>);
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32JalrAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/jalr.rs
+++ b/extensions/rv32im/circuit/src/adapters/jalr.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -25,7 +25,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::{not, select},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -114,7 +114,11 @@ impl<F: Field> BaseAir<F> for Rv32LoadStoreAdapterAir {
         Rv32LoadStoreAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32LoadStoreAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32LoadStoreAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
     type Interface = Rv32LoadStoreAdapterAirInterface<AB>;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::{not, select},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -34,7 +34,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/loadstore.rs
+++ b/extensions/rv32im/circuit/src/adapters/loadstore.rs
@@ -20,7 +20,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::{not, select},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -114,11 +114,7 @@ impl<F: Field> BaseAir<F> for Rv32LoadStoreAdapterAir {
         Rv32LoadStoreAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32LoadStoreAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32LoadStoreAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32LoadStoreAdapterAir, Rv32LoadStoreAdapterCols<F>);
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32LoadStoreAdapterAir {
     type Interface = Rv32LoadStoreAdapterAirInterface<AB>;

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -14,7 +14,9 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -52,7 +54,11 @@ impl<F: Field> BaseAir<F> for Rv32MultAdapterAir {
         Rv32MultAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32MultAdapterAir, Rv32MultAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32MultAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32MultAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32MultAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -14,7 +14,9 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -23,7 +25,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::{tracing_write, RV32_REGISTER_NUM_LIMBS};

--- a/extensions/rv32im/circuit/src/adapters/mul.rs
+++ b/extensions/rv32im/circuit/src/adapters/mul.rs
@@ -14,9 +14,7 @@ use openvm_circuit::{
         MemoryAddress, MemoryAuxColsFactory,
     },
 };
-use openvm_circuit_primitives::{
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
-};
+use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_AS,
@@ -54,11 +52,7 @@ impl<F: Field> BaseAir<F> for Rv32MultAdapterAir {
         Rv32MultAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32MultAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32MultAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32MultAdapterAir, Rv32MultAdapterCols<F>);
 
 impl<AB: InteractionBuilder> VmAdapterAir<AB> for Rv32MultAdapterAir {
     type Interface = BasicAdapterInterface<

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -22,7 +22,6 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    ColumnsAir,
 };
 
 use super::RV32_REGISTER_NUM_LIMBS;

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -60,22 +60,17 @@ impl<F: Field> BaseAir<F> for Rv32RdWriteAdapterAir {
         Rv32RdWriteAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32RdWriteAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32RdWriteAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32RdWriteAdapterAir, Rv32RdWriteAdapterCols<F>);
 
 impl<F: Field> BaseAir<F> for Rv32CondRdWriteAdapterAir {
     fn width(&self) -> usize {
         Rv32CondRdWriteAdapterCols::<F>::width()
     }
 }
-impl<F: Field> ColumnsAir<F> for Rv32CondRdWriteAdapterAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32CondRdWriteAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    Rv32CondRdWriteAdapterAir,
+    Rv32CondRdWriteAdapterCols<F>
+);
 
 impl Rv32RdWriteAdapterAir {
     /// If `needs_write` is provided:

--- a/extensions/rv32im/circuit/src/adapters/rdwrite.rs
+++ b/extensions/rv32im/circuit/src/adapters/rdwrite.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
     },
 };
 use openvm_circuit_primitives::{
-    utils::not, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    utils::not, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -60,17 +60,22 @@ impl<F: Field> BaseAir<F> for Rv32RdWriteAdapterAir {
         Rv32RdWriteAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(Rv32RdWriteAdapterAir, Rv32RdWriteAdapterCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32RdWriteAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32RdWriteAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<F: Field> BaseAir<F> for Rv32CondRdWriteAdapterAir {
     fn width(&self) -> usize {
         Rv32CondRdWriteAdapterCols::<F>::width()
     }
 }
-openvm_circuit_primitives::impl_columns_air!(
-    Rv32CondRdWriteAdapterAir,
-    Rv32CondRdWriteAdapterCols<F>
-);
+impl<F: Field> ColumnsAir<F> for Rv32CondRdWriteAdapterAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32CondRdWriteAdapterCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl Rv32RdWriteAdapterAir {
     /// If `needs_write` is provided:

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -52,7 +52,11 @@ impl<F: Field> BaseAir<F> for Rv32AuipcCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32AuipcCoreAir {}
-openvm_circuit_primitives::impl_columns_air!(Rv32AuipcCoreAir, Rv32AuipcCoreCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32AuipcCoreAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32AuipcCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32AuipcCoreAir
 where

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -22,7 +22,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::adapters::{

--- a/extensions/rv32im/circuit/src/auipc/core.rs
+++ b/extensions/rv32im/circuit/src/auipc/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -52,11 +52,7 @@ impl<F: Field> BaseAir<F> for Rv32AuipcCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32AuipcCoreAir {}
-impl<F: Field> ColumnsAir<F> for Rv32AuipcCoreAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32AuipcCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32AuipcCoreAir, Rv32AuipcCoreCols<F>);
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32AuipcCoreAir
 where

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -55,11 +55,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>,
-    BaseAluCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <BaseAluCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -20,7 +20,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/base_alu/core.rs
+++ b/extensions/rv32im/circuit/src/base_alu/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -55,13 +55,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <BaseAluCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>,
+    BaseAluCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for BaseAluCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
     arch::*,
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
-use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_rv32im_transpiler::BranchEqualOpcode;
@@ -47,11 +47,11 @@ impl<F: Field, const NUM_LIMBS: usize> BaseAirWithPublicValues<F>
     for BranchEqualCoreAir<NUM_LIMBS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize]
-    BranchEqualCoreAir<NUM_LIMBS>,
-    BranchEqualCoreCols<F, NUM_LIMBS>
-);
+impl<F: Field, const NUM_LIMBS: usize> ColumnsAir<F> for BranchEqualCoreAir<NUM_LIMBS> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <BranchEqualCoreCols<F, NUM_LIMBS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize> VmCoreAir<AB, I> for BranchEqualCoreAir<NUM_LIMBS>
 where

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
     arch::*,
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
-use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_rv32im_transpiler::BranchEqualOpcode;
@@ -12,7 +12,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/branch_eq/core.rs
+++ b/extensions/rv32im/circuit/src/branch_eq/core.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
     arch::*,
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
-use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
+use openvm_circuit_primitives::{utils::not, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_rv32im_transpiler::BranchEqualOpcode;
@@ -47,11 +47,11 @@ impl<F: Field, const NUM_LIMBS: usize> BaseAirWithPublicValues<F>
     for BranchEqualCoreAir<NUM_LIMBS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize> ColumnsAir<F> for BranchEqualCoreAir<NUM_LIMBS> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <BranchEqualCoreCols<F, NUM_LIMBS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize]
+    BranchEqualCoreAir<NUM_LIMBS>,
+    BranchEqualCoreCols<F, NUM_LIMBS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize> VmCoreAir<AB, I> for BranchEqualCoreAir<NUM_LIMBS>
 where

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -66,13 +66,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <BranchLessThanCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
+    BranchLessThanCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -66,11 +66,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
-    BranchLessThanCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <BranchLessThanCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for BranchLessThanCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/branch_lt/core.rs
+++ b/extensions/rv32im/circuit/src/branch_lt/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -16,7 +16,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
     utils::{not, select},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -84,13 +84,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <DivRemCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    DivRemCoreAir<NUM_LIMBS, LIMB_BITS>,
+    DivRemCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
     utils::{not, select},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -84,11 +84,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    DivRemCoreAir<NUM_LIMBS, LIMB_BITS>,
-    DivRemCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <DivRemCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for DivRemCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/divrem/core.rs
+++ b/extensions/rv32im/circuit/src/divrem/core.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
     utils::{not, select},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -22,7 +22,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -14,7 +14,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    ColumnsAir, StructReflection, StructReflectionHelper,
+    StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{
@@ -91,11 +91,7 @@ impl<F: Field> BaseAir<F> for Rv32HintStoreAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32HintStoreAir {}
 impl<F: Field> PartitionedBaseAir<F> for Rv32HintStoreAir {}
-impl<F: Field> ColumnsAir<F> for Rv32HintStoreAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32HintStoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32HintStoreAir, Rv32HintStoreCols<F>);
 
 impl<AB: InteractionBuilder> Air<AB> for Rv32HintStoreAir {
     fn eval(&self, builder: &mut AB) {

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -14,7 +14,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{
@@ -34,7 +34,7 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::{dense::RowMajorMatrix, Matrix},
     p3_maybe_rayon::prelude::*,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::adapters::{read_rv32_register, tracing_read, tracing_write};

--- a/extensions/rv32im/circuit/src/hintstore/mod.rs
+++ b/extensions/rv32im/circuit/src/hintstore/mod.rs
@@ -14,7 +14,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    StructReflection, StructReflectionHelper,
+    ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::{AlignedBorrow, AlignedBytesBorrow};
 use openvm_instructions::{
@@ -91,7 +91,11 @@ impl<F: Field> BaseAir<F> for Rv32HintStoreAir {
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32HintStoreAir {}
 impl<F: Field> PartitionedBaseAir<F> for Rv32HintStoreAir {}
-openvm_circuit_primitives::impl_columns_air!(Rv32HintStoreAir, Rv32HintStoreCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32HintStoreAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32HintStoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB: InteractionBuilder> Air<AB> for Rv32HintStoreAir {
     fn eval(&self, builder: &mut AB) {

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -50,11 +50,7 @@ impl<F: Field> BaseAir<F> for Rv32JalLuiCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32JalLuiCoreAir {}
-impl<F: Field> ColumnsAir<F> for Rv32JalLuiCoreAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32JalLuiCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32JalLuiCoreAir, Rv32JalLuiCoreCols<F>);
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32JalLuiCoreAir
 where

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -50,7 +50,11 @@ impl<F: Field> BaseAir<F> for Rv32JalLuiCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32JalLuiCoreAir {}
-openvm_circuit_primitives::impl_columns_air!(Rv32JalLuiCoreAir, Rv32JalLuiCoreCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32JalLuiCoreAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32JalLuiCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32JalLuiCoreAir
 where

--- a/extensions/rv32im/circuit/src/jal_lui/core.rs
+++ b/extensions/rv32im/circuit/src/jal_lui/core.rs
@@ -6,7 +6,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::adapters::{

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -23,7 +23,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::adapters::{

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -59,11 +59,7 @@ impl<F: Field> BaseAir<F> for Rv32JalrCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32JalrCoreAir {}
-impl<F: Field> ColumnsAir<F> for Rv32JalrCoreAir {
-    fn columns(&self) -> Option<Vec<String>> {
-        <Rv32JalrCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(Rv32JalrCoreAir, Rv32JalrCoreCols<F>);
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32JalrCoreAir
 where

--- a/extensions/rv32im/circuit/src/jalr/core.rs
+++ b/extensions/rv32im/circuit/src/jalr/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -59,7 +59,11 @@ impl<F: Field> BaseAir<F> for Rv32JalrCoreAir {
 }
 
 impl<F: Field> BaseAirWithPublicValues<F> for Rv32JalrCoreAir {}
-openvm_circuit_primitives::impl_columns_air!(Rv32JalrCoreAir, Rv32JalrCoreCols<F>);
+impl<F: Field> ColumnsAir<F> for Rv32JalrCoreAir {
+    fn columns(&self) -> Option<Vec<String>> {
+        <Rv32JalrCoreCols<F> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I> VmCoreAir<AB, I> for Rv32JalrCoreAir
 where

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -61,13 +61,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <LessThanCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    LessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
+    LessThanCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -61,11 +61,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    LessThanCoreAir<NUM_LIMBS, LIMB_BITS>,
-    LessThanCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <LessThanCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for LessThanCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/less_than/core.rs
+++ b/extensions/rv32im/circuit/src/less_than/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::select,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -68,11 +68,13 @@ impl<F: Field, const NUM_CELLS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_CELLS: usize, const LIMB_BITS: usize]
-    LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>,
-    LoadSignExtendCoreCols<F, NUM_CELLS>
-);
+impl<F: Field, const NUM_CELLS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <LoadSignExtendCoreCols<F, NUM_CELLS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_CELLS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::select,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -24,7 +24,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::adapters::{LoadStoreInstruction, Rv32LoadStoreAdapterFiller};

--- a/extensions/rv32im/circuit/src/load_sign_extend/core.rs
+++ b/extensions/rv32im/circuit/src/load_sign_extend/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     utils::select,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
@@ -68,13 +68,11 @@ impl<F: Field, const NUM_CELLS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_CELLS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <LoadSignExtendCoreCols<F, NUM_CELLS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_CELLS: usize, const LIMB_BITS: usize]
+    LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>,
+    LoadSignExtendCoreCols<F, NUM_CELLS>
+);
 
 impl<AB, I, const NUM_CELLS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for LoadSignExtendCoreAir<NUM_CELLS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
-    AlignedBorrow, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBorrow, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_NUM_LIMBS, LocalOpcode,
@@ -75,11 +75,11 @@ impl<F: Field, const NUM_CELLS: usize> BaseAir<F> for LoadStoreCoreAir<NUM_CELLS
 }
 
 impl<F: Field, const NUM_CELLS: usize> BaseAirWithPublicValues<F> for LoadStoreCoreAir<NUM_CELLS> {}
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_CELLS: usize]
-    LoadStoreCoreAir<NUM_CELLS>,
-    LoadStoreCoreCols<F, NUM_CELLS>
-);
+impl<F: Field, const NUM_CELLS: usize> ColumnsAir<F> for LoadStoreCoreAir<NUM_CELLS> {
+    fn columns(&self) -> Option<Vec<String>> {
+        <LoadStoreCoreCols<F, NUM_CELLS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_CELLS: usize> VmCoreAir<AB, I> for LoadStoreCoreAir<NUM_CELLS>
 where

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
-    AlignedBorrow, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBorrow, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_NUM_LIMBS, LocalOpcode,
@@ -75,11 +75,11 @@ impl<F: Field, const NUM_CELLS: usize> BaseAir<F> for LoadStoreCoreAir<NUM_CELLS
 }
 
 impl<F: Field, const NUM_CELLS: usize> BaseAirWithPublicValues<F> for LoadStoreCoreAir<NUM_CELLS> {}
-impl<F: Field, const NUM_CELLS: usize> ColumnsAir<F> for LoadStoreCoreAir<NUM_CELLS> {
-    fn columns(&self) -> Option<Vec<String>> {
-        <LoadStoreCoreCols<F, NUM_CELLS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_CELLS: usize]
+    LoadStoreCoreAir<NUM_CELLS>,
+    LoadStoreCoreCols<F, NUM_CELLS>
+);
 
 impl<AB, I, const NUM_CELLS: usize> VmCoreAir<AB, I> for LoadStoreCoreAir<NUM_CELLS>
 where

--- a/extensions/rv32im/circuit/src/loadstore/core.rs
+++ b/extensions/rv32im/circuit/src/loadstore/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
-    AlignedBorrow, AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBorrow, AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_instructions::{
     instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV32_REGISTER_NUM_LIMBS, LocalOpcode,
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 use crate::adapters::{LoadStoreInstruction, Rv32LoadStoreAdapterFiller};

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -18,7 +18,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 
 #[repr(C)]

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -47,11 +47,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>,
-    MultiplicationCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <MultiplicationCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/mul/core.rs
+++ b/extensions/rv32im/circuit/src/mul/core.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -47,13 +47,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <MultiplicationCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>,
+    MultiplicationCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for MultiplicationCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -56,13 +56,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for MulHCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for MulHCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <MulHCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    MulHCoreAir<NUM_LIMBS, LIMB_BITS>,
+    MulHCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for MulHCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -56,11 +56,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for MulHCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    MulHCoreAir<NUM_LIMBS, LIMB_BITS>,
-    MulHCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for MulHCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <MulHCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for MulHCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/mulh/core.rs
+++ b/extensions/rv32im/circuit/src/mulh/core.rs
@@ -10,7 +10,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     range_tuple::{RangeTupleCheckerBus, SharedRangeTupleCheckerChip},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -71,13 +71,11 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
-    for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>
-{
-    fn columns(&self) -> Option<Vec<String>> {
-        <ShiftCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
-    }
-}
+openvm_circuit_primitives::impl_columns_air!(
+    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
+    ShiftCoreAir<NUM_LIMBS, LIMB_BITS>,
+    ShiftCoreCols<F, NUM_LIMBS, LIMB_BITS>
+);
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -20,7 +20,7 @@ use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
-    BaseAirWithPublicValues, ColumnsAir,
+    BaseAirWithPublicValues,
 };
 use strum::IntoEnumIterator;
 

--- a/extensions/rv32im/circuit/src/shift/core.rs
+++ b/extensions/rv32im/circuit/src/shift/core.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
     bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
     utils::not,
     var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
-    AlignedBytesBorrow, StructReflection, StructReflectionHelper,
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
@@ -71,11 +71,13 @@ impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> BaseAirWithPublic
     for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>
 {
 }
-openvm_circuit_primitives::impl_columns_air!(
-    [const NUM_LIMBS: usize, const LIMB_BITS: usize]
-    ShiftCoreAir<NUM_LIMBS, LIMB_BITS>,
-    ShiftCoreCols<F, NUM_LIMBS, LIMB_BITS>
-);
+impl<F: Field, const NUM_LIMBS: usize, const LIMB_BITS: usize> ColumnsAir<F>
+    for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>
+{
+    fn columns(&self) -> Option<Vec<String>> {
+        <ShiftCoreCols<F, NUM_LIMBS, LIMB_BITS> as openvm_circuit_primitives::StructReflectionHelper>::struct_reflection()
+    }
+}
 
 impl<AB, I, const NUM_LIMBS: usize, const LIMB_BITS: usize> VmCoreAir<AB, I>
     for ShiftCoreAir<NUM_LIMBS, LIMB_BITS>

--- a/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/air.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/air.rs
@@ -1,11 +1,11 @@
-use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, SubAir};
+use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, ColumnsAir, SubAir};
 use openvm_sha2_air::{compose, Sha2BlockHasherSubAir};
 use openvm_stark_backend::{
     interaction::{BusIndex, InteractionBuilder, PermutationCheckBus},
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::{Field, PrimeCharacteristicRing},
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use crate::{

--- a/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
@@ -9,7 +9,9 @@ use openvm_circuit::{
         SystemPort,
     },
 };
-use openvm_circuit_primitives::{bitwise_op_lookup::BitwiseOperationLookupBus, utils::compose};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupBus, utils::compose, ColumnsAir,
+};
 use openvm_instructions::riscv::{
     RV32_CELL_BITS, RV32_MEMORY_AS, RV32_REGISTER_AS, RV32_REGISTER_NUM_LIMBS,
 };
@@ -19,7 +21,7 @@ use openvm_stark_backend::{
     p3_air::{Air, AirBuilder, BaseAir},
     p3_field::PrimeCharacteristicRing,
     p3_matrix::Matrix,
-    BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    BaseAirWithPublicValues, PartitionedBaseAir,
 };
 
 use super::config::Sha2MainChipConfig;

--- a/guest-libs/verify-stark/circuit/src/commit/air.rs
+++ b/guest-libs/verify-stark/circuit/src/commit/air.rs
@@ -1,12 +1,12 @@
 use std::{array::from_fn, borrow::Borrow};
 
-use openvm_circuit_primitives::SubAir;
+use openvm_circuit_primitives::{ColumnsAir, SubAir};
 use openvm_continuations::circuit::subair::{
     MerkleRootBus, MerkleTreeCols, MerkleTreeInternalBus, MerkleTreeSubAir,
 };
 use openvm_recursion_circuit::{bus::Poseidon2CompressBus, utils::assert_zeros};
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};

--- a/guest-libs/verify-stark/circuit/src/output/air.rs
+++ b/guest-libs/verify-stark/circuit/src/output/air.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use itertools::{fold, Itertools};
-use openvm_circuit_primitives::{utils::assert_array_eq, AlignedBorrow};
+use openvm_circuit_primitives::{utils::assert_array_eq, AlignedBorrow, ColumnsAir};
 use openvm_continuations::utils::digests_to_poseidon2_input;
 use openvm_deferral_circuit::canonicity::{CanonicityAuxCols, CanonicitySubAir};
 use openvm_recursion_circuit::{
@@ -9,7 +9,7 @@ use openvm_recursion_circuit::{
     prelude::DIGEST_SIZE,
     primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
 };
-use openvm_stark_backend::{interaction::InteractionBuilder, ColumnsAir, PartitionedBaseAir};
+use openvm_stark_backend::{interaction::InteractionBuilder, PartitionedBaseAir};
 use p3_air::{Air, AirBuilder, BaseAir, BaseAirWithPublicValues};
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::Matrix;

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -1,7 +1,7 @@
 use std::{array::from_fn, borrow::Borrow};
 
 use openvm_circuit::arch::{ExitCode, POSEIDON2_WIDTH};
-use openvm_circuit_primitives::{utils::assert_array_eq, SubAir};
+use openvm_circuit_primitives::{utils::assert_array_eq, ColumnsAir, SubAir};
 use openvm_continuations::{
     circuit::{
         deferral::DeferralCircuitPvs,
@@ -28,7 +28,7 @@ use openvm_recursion_circuit::{
 };
 use openvm_recursion_circuit_derive::AlignedBorrow;
 use openvm_stark_backend::{
-    interaction::InteractionBuilder, BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir,
+    interaction::InteractionBuilder, BaseAirWithPublicValues, PartitionedBaseAir,
 };
 use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use openvm_verify_stark_host::pvs::{


### PR DESCRIPTION
In order to upstream the `ColumnsAir` trait to `openvm-org/openvm`, we removed it from `stark-backend` (https://github.com/powdr-labs/stark-backend/pull/27, so that the change can be atomic). This PR [adds to `openvm`](https://github.com/powdr-labs/openvm/blob/8a5d23a59910cfda6a02c073136a70776df43418/crates/vm/src/arch/extensions.rs#L58-L76).

There are 3 changes in 3 commits:
1. 9a25af6d68cbdb52236a72cc67c7f6d324e5f67c: Implements the type and changes imports everywhere.
2. 44ed029ec7e22f7ab765c119a68b0bed38fa9cc7: Minimizes the diff to upstream by adding an `impl_columns_air` macro.
3. 8a5d23a59910cfda6a02c073136a70776df43418: Uses the crates.io version of `struct-reflection`.

There is also a second branch with the same content, `v2-powdr-beta.2-reorganized`. It organizes the code into two commits on top of the upstream `v2.0.0-beta.2` (see [this diff](https://github.com/openvm-org/openvm/compare/v2.0.0-beta.2...powdr-labs:openvm:v2-powdr-beta.2-reorganized?expand=1)):
1. fdcae837b149fe4d88c82ca52c8270071275221c: A self-contained commit to introduce and implement the `ColumnsAir` everywhere. Hopefully, we can upstream this.
2. 099bbceb9d81a9c73cb8258e42f58f1f2cc9cbf2: The remaining changes in our fork.

I would propose that we review this branch, but then use `v2-powdr-beta.2-reorganized`.