### PR TITLE
Add sub-stage timing spans to system trace generation

### DIFF
--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -1,5 +1,6 @@
 //! [MemoryController] can be considered as the Memory Chip Complex for the CPU Backend.
 use std::{collections::BTreeMap, fmt::Debug, marker::PhantomData, sync::Arc};
+use tracing::info_span;
 
 use getset::{Getters, MutGetters};
 use openvm_circuit_primitives::{
@@ -184,32 +185,39 @@ impl<F: VmField> MemoryController<F> {
         } = &mut self.interface_chip;
 
         let hasher = self.hasher_chip.as_ref().unwrap();
-        boundary_chip.finalize(initial_memory, &final_memory, hasher.as_ref());
+        info_span!("boundary_finalize").in_scope(|| {
+            boundary_chip.finalize(initial_memory, &final_memory, hasher.as_ref());
+        });
 
         // Rechunk DEFAULT_BLOCK_SIZE blocks into CHUNK-sized blocks for merkle_chip
         // Note: Equipartition key is (addr_space, ptr) where ptr is the starting pointer
-        let final_memory_values: Equipartition<F, CHUNK> =
-            group_touched_memory_by_chunk(&final_memory)
-                .into_iter()
-                .map(|((addr_space, chunk_label), blocks)| {
-                    let chunk_ptr = chunk_label * CHUNK as u32;
-                    let mut values = std::array::from_fn(|i| unsafe {
-                        initial_memory.get_f::<F>(addr_space, chunk_ptr + i as u32)
-                    });
-                    for (block_idx, _, block_values) in blocks {
-                        for (i, val) in block_values.into_iter().enumerate() {
-                            values[block_idx * DEFAULT_BLOCK_SIZE + i] = val;
+        let final_memory_values: Equipartition<F, CHUNK> = info_span!("rechunk_memory")
+            .in_scope(|| {
+                group_touched_memory_by_chunk(&final_memory)
+                    .into_iter()
+                    .map(|((addr_space, chunk_label), blocks)| {
+                        let chunk_ptr = chunk_label * CHUNK as u32;
+                        let mut values = std::array::from_fn(|i| unsafe {
+                            initial_memory.get_f::<F>(addr_space, chunk_ptr + i as u32)
+                        });
+                        for (block_idx, _, block_values) in blocks {
+                            for (i, val) in block_values.into_iter().enumerate() {
+                                values[block_idx * DEFAULT_BLOCK_SIZE + i] = val;
+                            }
                         }
-                    }
-                    ((addr_space, chunk_ptr), values)
-                })
-                .collect();
+                        ((addr_space, chunk_ptr), values)
+                    })
+                    .collect()
+            });
         merkle_chip.finalize(initial_memory, &final_memory_values, hasher.as_ref());
 
-        vec![
-            boundary_chip.generate_proving_ctx(()),
-            merkle_chip.generate_proving_ctx(),
-        ]
+        let boundary_ctx = info_span!("boundary_tracegen").in_scope(|| {
+            boundary_chip.generate_proving_ctx(())
+        });
+        let merkle_ctx = info_span!("merkle_tracegen").in_scope(|| {
+            merkle_chip.generate_proving_ctx()
+        });
+        vec![boundary_ctx, merkle_ctx]
     }
 
     /// Return the number of AIRs in the memory controller.

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -5,7 +5,7 @@ use openvm_stark_backend::{
     p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix, prover::AirProvingContext,
     StarkProtocolConfig, Val,
 };
-use tracing::instrument;
+use tracing::{info_span, instrument};
 
 use crate::{
     arch::{hasher::HasherChip, VmField},
@@ -21,7 +21,7 @@ use crate::{
 };
 
 impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
-    #[instrument(name = "merkle_finalize", level = "debug", skip_all)]
+    #[instrument(name = "merkle_finalize", level = "info", skip_all)]
     pub(crate) fn finalize(
         &mut self,
         initial_memory: &MemoryImage,
@@ -30,8 +30,20 @@ impl<const CHUNK: usize, F: PrimeField32> MemoryMerkleChip<CHUNK, F> {
     ) {
         assert!(self.final_state.is_none(), "Merkle chip already finalized");
         let memory_dimensions = &self.air.memory_dimensions;
-        let mut tree = MerkleTree::from_memory(initial_memory, memory_dimensions, hasher);
-        self.final_state = Some(tree.finalize(hasher, final_memory, memory_dimensions));
+        #[cfg(feature = "metrics")]
+        metrics::gauge!("merkle_touched_chunks").set(final_memory.len() as f64);
+        let mut tree = info_span!("merkle_from_memory").in_scope(|| {
+            MerkleTree::from_memory(initial_memory, memory_dimensions, hasher)
+        });
+        #[cfg(feature = "metrics")]
+        metrics::gauge!("merkle_initial_tree_nodes").set(tree.num_nodes() as f64);
+        self.final_state = info_span!("merkle_tree_finalize").in_scope(|| {
+            Some(tree.finalize(hasher, final_memory, memory_dimensions))
+        });
+        #[cfg(feature = "metrics")]
+        if let Some(ref state) = self.final_state {
+            metrics::gauge!("merkle_unpadded_rows").set(state.rows.len() as f64);
+        }
         self.top_tree = tree.top_tree(memory_dimensions.addr_space_height);
     }
 }

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -42,6 +42,11 @@ impl<F: PrimeField32, const CHUNK: usize> MerkleTree<F, CHUNK> {
         self.get_node(1)
     }
 
+    /// Returns the number of non-default nodes stored in the tree.
+    pub fn num_nodes(&self) -> usize {
+        self.nodes.len()
+    }
+
     pub fn get_node(&self, index: u64) -> [F; CHUNK] {
         self.nodes
             .get(&index)

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -269,7 +269,7 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
     /// each). This function rechunks into CHUNK-sized (8 bytes) groups with per-block
     /// timestamps. Untouched blocks within a touched chunk get values from initial_memory and
     /// timestamp 0.
-    #[instrument(name = "boundary_finalize", level = "debug", skip_all)]
+    #[instrument(name = "boundary_finalize", level = "info", skip_all)]
     pub(crate) fn finalize<H>(
         &mut self,
         initial_memory: &MemoryImage,
@@ -311,6 +311,8 @@ impl<const CHUNK: usize, F: PrimeField32> PersistentBoundaryChip<F, CHUNK> {
                 }
             })
             .collect();
+        #[cfg(feature = "metrics")]
+        metrics::gauge!("boundary_touched_chunks").set(final_touched_labels.len() as f64);
         for l in &final_touched_labels {
             hasher.receive(&l.init_values);
             hasher.receive(&l.final_values);

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use derive_more::derive::From;
+use tracing::info_span;
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor};
 #[cfg(feature = "aot")]
 use openvm_circuit_derive::{AotExecutor, AotMeteredExecutor};
@@ -355,12 +356,16 @@ where
         } = system_records;
 
         self.program_chip.filtered_exec_frequencies = filtered_exec_frequencies;
-        let program_ctx = self.program_chip.generate_proving_ctx(());
+        let program_ctx = info_span!("program_tracegen").in_scope(|| {
+            self.program_chip.generate_proving_ctx(())
+        });
         self.connector_chip.begin(from_state);
         self.connector_chip.end(to_state, exit_code);
         let connector_ctx = self.connector_chip.generate_proving_ctx(());
 
-        let memory_ctxs = self.memory_controller.generate_proving_ctx(touched_memory);
+        let memory_ctxs = info_span!("memory_tracegen").in_scope(|| {
+            self.memory_controller.generate_proving_ctx(touched_memory)
+        });
 
         [program_ctx, connector_ctx]
             .into_iter()


### PR DESCRIPTION
## Summary

Add sub-stage timing spans to system trace generation for performance profiling.

All spans are `info` level, captured by `TimingMetricsLayer` and emitted as `*_time_ms` gauge metrics.

## New spans

**System chip trace gen** (`system/mod.rs`):
- `program_tracegen` — program chip trace gen
- `memory_tracegen` — entire memory controller

**Memory controller** (`memory/controller/mod.rs`):
- `boundary_finalize` — boundary chip finalize (promoted from `debug` to `info`)
- `rechunk_memory` — regrouping blocks into chunks
- `boundary_tracegen` — boundary trace matrix creation
- `merkle_tracegen` — merkle trace matrix creation

**Merkle chip** (`memory/merkle/trace.rs`):
- `merkle_finalize` — overall merkle finalize (promoted from `debug` to `info`)
- `merkle_from_memory` — initial merkle tree construction
- `merkle_tree_finalize` — updating tree with touched leaves

## New counter metrics

- `boundary_touched_chunks` — actual (unpadded) chunk count
- `merkle_touched_chunks` — touched leaf count
- `merkle_initial_tree_nodes` — non-default nodes after `from_memory`
- `merkle_unpadded_rows` — actual merkle trace rows before padding

These metrics were used to determine that the APC trace gen overhead is NOT in system chips (memory/merkle), but in PowdrAir trace generation.
