### PR TITLE
Update CUDA kernels to support powdr-wasm's FP_AS

### DIFF
--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -47,9 +47,13 @@ __global__ void cukernel_persistent_boundary_tracegen(
         if (row_idx % 2 == 0) {
             FpArray<8> init_values;
             uint32_t addr_space_idx = record.address_space - 1;
+            // Address spaces >= DEFERRAL_AS use native32 cell type (field elements).
+            // Address spaces < DEFERRAL_AS use U8 cell type (bytes).
+            // Extensions can define additional native32 address spaces above
+            // DEFERRAL_AS (e.g. crush's FP_AS = 5).
             if (initial_mem[addr_space_idx]) {
                 init_values =
-                    record.address_space == DEFERRAL_AS
+                    record.address_space >= DEFERRAL_AS
                         ? FpArray<8>::from_raw_array(
                             reinterpret_cast<uint32_t const *>(
                                 initial_mem[addr_space_idx]

--- a/crates/vm/cuda/src/system/inventory.cu
+++ b/crates/vm/cuda/src/system/inventory.cu
@@ -42,8 +42,10 @@ __device__ inline bool same_output_block(
 /// field elements. The output values must be in Montgomery form because they are
 /// stored directly into MemoryInventoryRecord.values, which boundary.cu later
 /// reads via FpArray::from_raw_array (a raw copy that assumes Montgomery encoding).
-/// DEFERRAL_AS stores field elements (4 bytes per cell, already Montgomery-encoded).
+/// Address spaces >= DEFERRAL_AS stores field elements (4 bytes per cell, already Montgomery-encoded).
 /// Other address spaces store u8 cells (1 byte per cell).
+/// Note: originally only DEFERRAL_AS stored field elements, this change was
+/// made to support powdr-wasm's (crush) FP_AS address space.
 __device__ inline void read_initial_chunk(
     uint32_t *out_values, // Montgomery-encoded Fp values
     uint8_t const *const *initial_mem,
@@ -59,7 +61,7 @@ __device__ inline void read_initial_chunk(
         }
         return;
     }
-    if (address_space == DEFERRAL_AS) {
+    if (address_space >= DEFERRAL_AS) {
         // F-type cells: 4 bytes per cell, already raw Montgomery u32
         uint32_t const *cells = reinterpret_cast<uint32_t const *>(mem) + chunk_ptr;
         #pragma unroll

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -500,6 +500,9 @@ extern "C" int _build_merkle_subtree(
         case 3:
             merkle_tree_init<3><<<grid, block, 0, stream>>>(data, tree + (size - 1));
             break;
+        case 4:
+            merkle_tree_init<4><<<grid, block, 0, stream>>>(data, tree + (size - 1));
+            break;
         default:
             return -1;
         }


### PR DESCRIPTION
Add support for address space 5, used by powdr-wasm's (crush) FP_AS.

- Add case to the switch statement in _build_merkle_subtree
- Update boundary and inventory CUDA kernels to support address space 5 using native32 cell type (field elements)